### PR TITLE
feat: add Dashboard as home page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-day-picker": "^9.9.0",
         "react-dom": "19.1.1",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.9.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "3.3.1",
         "tailwindcss": "4.1.11",
@@ -2414,6 +2415,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2680,6 +2717,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.11",
@@ -3242,6 +3291,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3333,6 +3445,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4300,6 +4418,127 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4386,6 +4625,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -4715,6 +4960,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
+      "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
@@ -5014,6 +5269,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5538,6 +5799,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5584,6 +5856,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -7916,8 +8197,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7944,6 +8225,30 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -8065,6 +8370,52 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.0.tgz",
+      "integrity": "sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8174,6 +8525,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -9344,6 +9701,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-day-picker": "^9.9.0",
     "react-dom": "19.1.1",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.9.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "3.3.1",
     "tailwindcss": "4.1.11",

--- a/src/componenets/Dashboard/HabitProgressChart.tsx
+++ b/src/componenets/Dashboard/HabitProgressChart.tsx
@@ -1,0 +1,79 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import type { Habit } from "@/zustand/habbitStore";
+import { getCompletionRate } from "@/lib/getCompletionRate";
+
+interface HabitProgressChartProps {
+  habits: Habit[];
+}
+
+const tooltipStyle = {
+  background: "#0b1020",
+  border: "1px solid rgba(255,255,255,0.15)",
+  borderRadius: 8,
+  color: "#fff",
+} as const;
+
+const truncate = (value: string) =>
+  value.length > 14 ? `${value.slice(0, 13)}…` : value;
+
+export function HabitProgressChart({ habits }: HabitProgressChartProps) {
+  if (habits.length === 0) {
+    return (
+      <div className="flex h-[220px] items-center justify-center text-sm text-white/50">
+        No habits yet, start tracking on the Habit Tracker page.
+      </div>
+    );
+  }
+
+  const data = habits.map((h) => ({
+    name: h.name,
+    rate: getCompletionRate(h),
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <BarChart
+        data={data}
+        layout="vertical"
+        margin={{ top: 4, right: 16, bottom: 4, left: 8 }}
+      >
+        <CartesianGrid
+          horizontal={false}
+          stroke="rgba(255,255,255,0.08)"
+        />
+        <XAxis
+          type="number"
+          domain={[0, 100]}
+          tickFormatter={(v) => `${v}%`}
+          tick={{ fill: "rgba(255,255,255,0.6)", fontSize: 11 }}
+          axisLine={{ stroke: "rgba(255,255,255,0.15)" }}
+          tickLine={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={90}
+          tickFormatter={truncate}
+          tick={{ fill: "rgba(255,255,255,0.7)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <Tooltip
+          contentStyle={tooltipStyle}
+          itemStyle={{ color: "#fff" }}
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          formatter={(value) => [`${value}%`, "Completion"]}
+        />
+        <Bar dataKey="rate" fill="#22d3ee" radius={[0, 4, 4, 0]} barSize={16} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/componenets/Dashboard/StatCard.tsx
+++ b/src/componenets/Dashboard/StatCard.tsx
@@ -1,0 +1,33 @@
+import type { LucideIcon } from "lucide-react";
+
+interface StatCardProps {
+  icon: LucideIcon;
+  label: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+  /** Tailwind text-color class for the icon, e.g. "text-emerald-400" */
+  accent?: string;
+}
+
+export function StatCard({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  accent = "text-white/60",
+}: StatCardProps) {
+  return (
+    <div className="relative overflow-hidden rounded-xl border border-white/10 bg-white/5 p-4 md:p-5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs md:text-sm text-white/60 uppercase tracking-wide">
+          {label}
+        </span>
+        <Icon className={`h-4 w-4 md:h-5 md:w-5 shrink-0 ${accent}`} />
+      </div>
+      <div className="mt-2 text-2xl md:text-3xl font-semibold text-white">
+        {value}
+      </div>
+      {sub && <div className="mt-1 text-xs text-white/50">{sub}</div>}
+    </div>
+  );
+}

--- a/src/componenets/Dashboard/TodoStatusChart.tsx
+++ b/src/componenets/Dashboard/TodoStatusChart.tsx
@@ -1,0 +1,75 @@
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from "recharts";
+import type { TodoStatus } from "@/lib/dashboardStats";
+
+interface TodoStatusChartProps {
+  byStatus: Record<TodoStatus, number>;
+  total: number;
+}
+
+// Colors mirror the status palette used across the app (see getStatusConfig).
+const STATUS_COLORS: Record<TodoStatus, string> = {
+  TODO: "#94a3b8", // slate
+  "In Progress": "#f59e0b", // amber
+  Done: "#10b981", // emerald
+  Kill: "#ef4444", // red
+};
+
+const ORDER: TodoStatus[] = ["TODO", "In Progress", "Done", "Kill"];
+
+const tooltipStyle = {
+  background: "#0b1020",
+  border: "1px solid rgba(255,255,255,0.15)",
+  borderRadius: 8,
+  color: "#fff",
+} as const;
+
+export function TodoStatusChart({ byStatus, total }: TodoStatusChartProps) {
+  if (total === 0) {
+    return (
+      <div className="flex h-[220px] items-center justify-center text-sm text-white/50">
+        No tasks yet, add some on the TODOs page.
+      </div>
+    );
+  }
+
+  const data = ORDER.map((status) => ({
+    name: status,
+    value: byStatus[status],
+    color: STATUS_COLORS[status],
+  })).filter((d) => d.value > 0);
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="value"
+          nameKey="name"
+          cx="50%"
+          cy="50%"
+          innerRadius={55}
+          outerRadius={85}
+          paddingAngle={2}
+          stroke="none"
+        >
+          {data.map((entry) => (
+            <Cell key={entry.name} fill={entry.color} />
+          ))}
+        </Pie>
+        <Tooltip contentStyle={tooltipStyle} itemStyle={{ color: "#fff" }} />
+        <Legend
+          formatter={(value) => (
+            <span className="text-xs text-white/70">{value}</span>
+          )}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/componenets/Dashboard/UpcomingAgenda.tsx
+++ b/src/componenets/Dashboard/UpcomingAgenda.tsx
@@ -1,0 +1,60 @@
+import { format, isToday, isTomorrow } from "date-fns";
+import { CheckSquare, Bell } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { UpcomingItem } from "@/lib/dashboardStats";
+
+interface UpcomingAgendaProps {
+  items: UpcomingItem[];
+  limit?: number;
+}
+
+const formatWhen = (date: Date): string => {
+  if (isToday(date)) return "Today";
+  if (isTomorrow(date)) return "Tomorrow";
+  return format(date, "EEE, MMM d");
+};
+
+export function UpcomingAgenda({ items, limit = 7 }: UpcomingAgendaProps) {
+  if (items.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-white/50">
+        Nothing upcoming, you're all caught up. 🎉
+      </div>
+    );
+  }
+
+  const visible = items.slice(0, limit);
+
+  return (
+    <ul className="space-y-2">
+      {visible.map((item) => {
+        const Icon = item.type === "todo" ? CheckSquare : Bell;
+        return (
+          <li
+            key={item.id}
+            className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 px-3 py-2"
+          >
+            <Icon className="h-4 w-4 shrink-0 text-white/50" />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm text-white">{item.title}</p>
+              <p className="text-xs text-white/50">
+                {formatWhen(item.date)}
+                {item.type === "reminder" && item.meta ? ` · ${item.meta}` : ""}
+                {item.type === "todo" && item.meta ? ` · ${item.meta}` : ""}
+              </p>
+            </div>
+            {item.overdue ? (
+              <Badge variant="destructive" className="shrink-0 text-xs">
+                Overdue
+              </Badge>
+            ) : (
+              <Badge variant="secondary" className="shrink-0 text-xs capitalize">
+                {item.type}
+              </Badge>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/componenets/Sidebar.tsx
+++ b/src/componenets/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useSidebarStore } from "@/zustand/sidebarStore";
 import { isAuthenticated } from "@/lib/authVerification";
 import { logout } from "@/lib/authHelpers";
 import {
+  LayoutDashboard,
   Timer,
   Target,
   CheckSquare,
@@ -73,10 +74,22 @@ export function Sidebar() {
                 variant="ghost"
                 size="icon"
                 className="h-10 w-10"
-                title="Focus Time"
+                title="Dashboard"
                 asChild
               >
                 <Link to="/">
+                  <LayoutDashboard className="h-5 w-5" />
+                </Link>
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10"
+                title="Focus Time"
+                asChild
+              >
+                <Link to="/focus">
                   <Timer className="h-5 w-5" />
                 </Link>
               </Button>
@@ -139,6 +152,18 @@ export function Sidebar() {
                 asChild
               >
                 <Link to="/">
+                  <LayoutDashboard className="h-4 w-4 mr-2" />
+                  Dashboard
+                </Link>
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start px-0"
+                asChild
+              >
+                <Link to="/focus">
                   <Timer className="h-4 w-4 mr-2" />
                   Focus Time
                 </Link>

--- a/src/lib/dashboardStats.ts
+++ b/src/lib/dashboardStats.ts
@@ -1,0 +1,137 @@
+import type { Todo } from "@/zustand/todoStore";
+import type { Reminder } from "@/zustand/reminderStore";
+import type { Habit } from "@/zustand/habbitStore";
+import { getCompletionRate } from "@/lib/getCompletionRate";
+
+export type TodoStatus = Todo["status"];
+
+export interface TodoStats {
+  total: number;
+  byStatus: Record<TodoStatus, number>;
+  done: number;
+  completionRate: number; // 0-100
+  overdue: number;
+  dueToday: number;
+}
+
+export interface HabitStats {
+  count: number;
+  averageCompletion: number; // 0-100
+  todayCompleted: number; // habits checked off for today
+}
+
+export interface UpcomingItem {
+  id: string;
+  type: "todo" | "reminder";
+  title: string;
+  date: Date; // date (+ time for reminders), used for sorting/display
+  overdue: boolean;
+  meta?: string; // e.g. reminder time, todo status
+}
+
+const startOfToday = (): Date => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+const isSameDay = (a: Date, b: Date): boolean =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+const combineDateTime = (date: Date, time?: string): Date => {
+  const d = new Date(date);
+  if (time) {
+    const [h, m] = time.split(":").map(Number);
+    d.setHours(Number.isFinite(h) ? h : 0, Number.isFinite(m) ? m : 0, 0, 0);
+  }
+  return d;
+};
+
+// A todo is "active" (still actionable) when it isn't Done or Killed.
+const isActiveTodo = (todo: Todo): boolean =>
+  todo.status !== "Done" && todo.status !== "Kill";
+
+export const getTodoStats = (todos: Todo[]): TodoStats => {
+  const byStatus: Record<TodoStatus, number> = {
+    TODO: 0,
+    "In Progress": 0,
+    Done: 0,
+    Kill: 0,
+  };
+
+  const today = startOfToday();
+  let overdue = 0;
+  let dueToday = 0;
+
+  for (const todo of todos) {
+    byStatus[todo.status] += 1;
+    if (todo.dueDate && isActiveTodo(todo)) {
+      if (todo.dueDate < today) overdue += 1;
+      else if (isSameDay(todo.dueDate, today)) dueToday += 1;
+    }
+  }
+
+  const total = todos.length;
+  const done = byStatus.Done;
+  const completionRate = total === 0 ? 0 : Math.round((done / total) * 100);
+
+  return { total, byStatus, done, completionRate, overdue, dueToday };
+};
+
+export const getHabitStats = (habits: Habit[]): HabitStats => {
+  const count = habits.length;
+  if (count === 0) {
+    return { count: 0, averageCompletion: 0, todayCompleted: 0 };
+  }
+
+  // completions array is Mon-Sun; JS getDay() has Sun=0, so shift to Mon=0.
+  const todayIndex = (new Date().getDay() + 6) % 7;
+  const totalRate = habits.reduce((sum, h) => sum + getCompletionRate(h), 0);
+  const todayCompleted = habits.filter((h) => h.completions[todayIndex]).length;
+
+  return {
+    count,
+    averageCompletion: Math.round(totalRate / count),
+    todayCompleted,
+  };
+};
+
+export const getUpcomingItems = (
+  todos: Todo[],
+  reminders: Reminder[],
+): UpcomingItem[] => {
+  const today = startOfToday();
+  const items: UpcomingItem[] = [];
+
+  for (const todo of todos) {
+    if (!todo.dueDate || !isActiveTodo(todo)) continue;
+    const day = new Date(todo.dueDate);
+    day.setHours(0, 0, 0, 0);
+    items.push({
+      id: `todo-${todo.id}`,
+      type: "todo",
+      title: todo.title,
+      date: todo.dueDate,
+      overdue: day < today,
+      meta: todo.status,
+    });
+  }
+
+  for (const reminder of reminders) {
+    if (reminder.completed) continue;
+    const day = new Date(reminder.date);
+    day.setHours(0, 0, 0, 0);
+    items.push({
+      id: `reminder-${reminder.id}`,
+      type: "reminder",
+      title: reminder.title,
+      date: combineDateTime(reminder.date, reminder.time),
+      overdue: day < today,
+      meta: reminder.time,
+    });
+  }
+
+  return items.sort((a, b) => a.date.getTime() - b.date.getTime());
+};

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ReminderRouteImport } from './routes/reminder'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as HabitTrackerRouteImport } from './routes/habit-tracker'
+import { Route as FocusRouteImport } from './routes/focus'
 import { Route as AgentRouteImport } from './routes/agent'
 import { Route as IndexRouteImport } from './routes/index'
 
@@ -42,6 +43,11 @@ const HabitTrackerRoute = HabitTrackerRouteImport.update({
   path: '/habit-tracker',
   getParentRoute: () => rootRouteImport,
 } as any)
+const FocusRoute = FocusRouteImport.update({
+  id: '/focus',
+  path: '/focus',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AgentRoute = AgentRouteImport.update({
   id: '/agent',
   path: '/agent',
@@ -56,6 +62,7 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/agent': typeof AgentRoute
+  '/focus': typeof FocusRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
   '/reminder': typeof ReminderRoute
@@ -65,6 +72,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/agent': typeof AgentRoute
+  '/focus': typeof FocusRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
   '/reminder': typeof ReminderRoute
@@ -75,6 +83,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/agent': typeof AgentRoute
+  '/focus': typeof FocusRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
   '/reminder': typeof ReminderRoute
@@ -86,6 +95,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/agent'
+    | '/focus'
     | '/habit-tracker'
     | '/login'
     | '/reminder'
@@ -95,6 +105,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/agent'
+    | '/focus'
     | '/habit-tracker'
     | '/login'
     | '/reminder'
@@ -104,6 +115,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/agent'
+    | '/focus'
     | '/habit-tracker'
     | '/login'
     | '/reminder'
@@ -114,6 +126,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AgentRoute: typeof AgentRoute
+  FocusRoute: typeof FocusRoute
   HabitTrackerRoute: typeof HabitTrackerRoute
   LoginRoute: typeof LoginRoute
   ReminderRoute: typeof ReminderRoute
@@ -158,6 +171,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HabitTrackerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/focus': {
+      id: '/focus'
+      path: '/focus'
+      fullPath: '/focus'
+      preLoaderRoute: typeof FocusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/agent': {
       id: '/agent'
       path: '/agent'
@@ -178,6 +198,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AgentRoute: AgentRoute,
+  FocusRoute: FocusRoute,
   HabitTrackerRoute: HabitTrackerRoute,
   LoginRoute: LoginRoute,
   ReminderRoute: ReminderRoute,

--- a/src/routes/focus.tsx
+++ b/src/routes/focus.tsx
@@ -1,0 +1,58 @@
+import { StatusHeader } from "@/componenets/StatusHeader";
+import { StatusTopLine } from "@/componenets/StatusTopLine";
+import { Timer } from "@/componenets/Timer/Timer";
+import { ModeSelection } from "@/componenets/ModeSelection";
+import { useModeStore, type ZendoroModeType } from "@/zustand/modeStore";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { isAuthenticated } from "@/lib/authVerification";
+
+export const Route = createFileRoute("/focus")({
+  component: RouteComponent,
+  beforeLoad: async () => {
+    if (!isAuthenticated()) {
+      throw redirect({
+        to: "/login",
+      });
+    }
+  },
+});
+
+function RouteComponent() {
+  useDocumentTitle("Focus Timer");
+
+  const { currentMode, fetchAvailableModes } = useModeStore() as {
+    currentMode: ZendoroModeType | null;
+    fetchAvailableModes: () => void;
+  };
+  const [timerKey, setTimerKey] = useState(0);
+
+  const focusTime = currentMode?.focusTime || 25 * 60 * 1000; // Default to 25 minutes
+
+  // Fetch available modes when component mounts
+  useEffect(() => {
+    if (!currentMode) {
+      fetchAvailableModes();
+    }
+  }, [currentMode, fetchAvailableModes]);
+
+  // Force timer re-render when mode changes
+  useEffect(() => {
+    setTimerKey((prev) => prev + 1);
+  }, [currentMode]);
+
+  return (
+    <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
+      <section className="flex gap-4 md:gap-8">
+        {/* Timer Panel */}
+        <div className="flex-1 flex flex-col gap-3 md:gap-4 items-center">
+          <StatusTopLine />
+          <ModeSelection />
+          <Timer key={timerKey} initialTime={focusTime} />
+          <StatusHeader />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,12 +1,22 @@
-import { StatusHeader } from "@/componenets/StatusHeader";
-import { StatusTopLine } from "@/componenets/StatusTopLine";
-import { Timer } from "@/componenets/Timer/Timer";
-import { ModeSelection } from "@/componenets/ModeSelection";
-import { useModeStore, type ZendoroModeType } from "@/zustand/modeStore";
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo } from "react";
+import { format } from "date-fns";
+import { Timer, CheckSquare, Bell, Target } from "lucide-react";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { isAuthenticated } from "@/lib/authVerification";
+import { useTodoStore } from "@/zustand/todoStore";
+import { useReminderStore } from "@/zustand/reminderStore";
+import { useHabitStore } from "@/zustand/habbitStore";
+import { useModeStore } from "@/zustand/modeStore";
+import {
+  getTodoStats,
+  getHabitStats,
+  getUpcomingItems,
+} from "@/lib/dashboardStats";
+import { StatCard } from "@/componenets/Dashboard/StatCard";
+import { TodoStatusChart } from "@/componenets/Dashboard/TodoStatusChart";
+import { HabitProgressChart } from "@/componenets/Dashboard/HabitProgressChart";
+import { UpcomingAgenda } from "@/componenets/Dashboard/UpcomingAgenda";
 
 export const Route = createFileRoute("/")({
   component: RouteComponent,
@@ -19,39 +29,127 @@ export const Route = createFileRoute("/")({
   },
 });
 
+function Panel({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative overflow-hidden rounded-xl border border-white/10 bg-white/5 p-4 md:p-5">
+      <h2 className="mb-3 text-base font-semibold text-white md:mb-4 md:text-lg">
+        {title}
+      </h2>
+      {children}
+    </div>
+  );
+}
+
+const greeting = (): string => {
+  const hour = new Date().getHours();
+  if (hour < 12) return "Good morning";
+  if (hour < 18) return "Good afternoon";
+  return "Good evening";
+};
+
 function RouteComponent() {
-  useDocumentTitle("Focus Timer");
+  useDocumentTitle("Dashboard");
 
-  const { currentMode, fetchAvailableModes } = useModeStore() as {
-    currentMode: ZendoroModeType | null;
-    fetchAvailableModes: () => void;
-  };
-  const [timerKey, setTimerKey] = useState(0);
+  const { todos, fetchTodos } = useTodoStore();
+  const {
+    reminders,
+    fetchReminders,
+    getTodayReminders,
+    getOverdueReminders,
+  } = useReminderStore();
+  const { habits, fetchHabits } = useHabitStore();
+  const { currentFocusSessionCount, fetchFocusSessionCount } =
+    useModeStore() as {
+      currentFocusSessionCount: number;
+      fetchFocusSessionCount: () => void;
+    };
 
-  const focusTime = currentMode?.focusTime || 25 * 60 * 1000; // Default to 25 minutes
-
-  // Fetch available modes when component mounts
   useEffect(() => {
-    if (!currentMode) {
-      fetchAvailableModes();
-    }
-  }, [currentMode, fetchAvailableModes]);
+    fetchTodos();
+    fetchReminders();
+    fetchHabits();
+    fetchFocusSessionCount();
+  }, [fetchTodos, fetchReminders, fetchHabits, fetchFocusSessionCount]);
 
-  // Force timer re-render when mode changes
-  useEffect(() => {
-    setTimerKey((prev) => prev + 1);
-  }, [currentMode]);
+  const todoStats = useMemo(() => getTodoStats(todos), [todos]);
+  const habitStats = useMemo(() => getHabitStats(habits), [habits]);
+  const upcoming = useMemo(
+    () => getUpcomingItems(todos, reminders),
+    [todos, reminders],
+  );
+
+  const todayReminders = getTodayReminders();
+  const overdueReminders = getOverdueReminders();
 
   return (
     <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
-      <section className="flex gap-4 md:gap-8">
-        {/* Timer Panel */}
-        <div className="flex-1 flex flex-col gap-3 md:gap-4 items-center">
-          <StatusTopLine />
-          <ModeSelection />
-          <Timer key={timerKey} initialTime={focusTime} />
-          <StatusHeader />
-        </div>
+      <header className="mb-6 md:mb-8">
+        <h1 className="mb-1 text-2xl font-bold text-white md:text-4xl">
+          Dashboard
+        </h1>
+        <p className="text-sm text-white/70 md:text-base">
+          {greeting()}, here's your overview for{" "}
+          {format(new Date(), "EEEE, MMMM d")}
+        </p>
+      </header>
+
+      {/* KPI summary */}
+      <section className="mb-6 grid grid-cols-2 gap-3 md:mb-8 md:gap-4 lg:grid-cols-4">
+        <StatCard
+          icon={Timer}
+          label="Focus Sessions"
+          value={currentFocusSessionCount}
+          sub="completed today"
+          accent="text-sky-400"
+        />
+        <StatCard
+          icon={CheckSquare}
+          label="Tasks Done"
+          value={`${todoStats.done}/${todoStats.total}`}
+          sub={`${todoStats.completionRate}% complete${
+            todoStats.overdue > 0 ? ` · ${todoStats.overdue} overdue` : ""
+          }`}
+          accent="text-emerald-400"
+        />
+        <StatCard
+          icon={Bell}
+          label="Reminders Today"
+          value={todayReminders}
+          sub={
+            overdueReminders > 0 ? `${overdueReminders} overdue` : "none overdue"
+          }
+          accent="text-amber-400"
+        />
+        <StatCard
+          icon={Target}
+          label="Habits Avg"
+          value={`${habitStats.averageCompletion}%`}
+          sub={`${habitStats.todayCompleted}/${habitStats.count} done today`}
+          accent="text-fuchsia-400"
+        />
+      </section>
+
+      {/* Charts */}
+      <section className="mb-6 grid grid-cols-1 gap-4 md:mb-8 md:gap-6 lg:grid-cols-2">
+        <Panel title="Task Status">
+          <TodoStatusChart byStatus={todoStats.byStatus} total={todoStats.total} />
+        </Panel>
+        <Panel title="Weekly Habit Completion">
+          <HabitProgressChart habits={habits} />
+        </Panel>
+      </section>
+
+      {/* Upcoming & overdue */}
+      <section>
+        <Panel title="Upcoming & Overdue">
+          <UpcomingAgenda items={upcoming} />
+        </Panel>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Dashboard becomes the home page** (`/`) — the first screen users see after login
- **Focus Timer moves to `/focus`** — fully intact, just a new route
- **KPI cards** — Focus sessions today, Tasks done/total, Reminders today + overdue count, Habits weekly average
- **Charts (Recharts)** — Task status donut (TODO / In Progress / Done / Kill) + Weekly habit completion bar chart per habit
- **Upcoming & Overdue agenda** — merged, date-sorted feed of todos with due dates and incomplete reminders; overdue items flagged in red
- **Sidebar** — Dashboard link added first; Focus Time link updated to `/focus`
- **No backend changes** — all data comes from existing Zustand stores and API endpoints

## Test plan

- [ ] Log in → landing page is the Dashboard (not the timer)
- [ ] `/focus` shows the Focus Timer as before
- [ ] Sidebar: Dashboard and Focus Time links both work in collapsed and expanded states
- [ ] Add a task with a past due date → appears as Overdue in KPI and agenda
- [ ] Add reminders for today and a past date → counts appear in Reminders Today card
- [ ] Add habits with some days checked → bars appear in Weekly Habit Completion chart
- [ ] Complete a focus session → Focus Sessions KPI updates
- [ ] Empty state (new account) → friendly placeholder messages, no broken charts
