### PR TITLE
feat: Kanban layout for todos and dashboard with drag-and-drop

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "--port", "5177"],
+      "port": 5177
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: zendoro_test
+    ports:
+      - "5432:5432"
+    volumes:
+      - zendoro_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    build: ./test-backend
+    ports:
+      - "3001:3001"
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/zendoro_test
+      JWT_SECRET: zendoro-test-secret
+      PORT: 3001
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  zendoro_pg_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "zendoro",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-accordion": "1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -541,6 +543,45 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
@@ -5804,7 +5845,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-accordion": "1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/src/componenets/Dashboard/UpcomingAgenda.tsx
+++ b/src/componenets/Dashboard/UpcomingAgenda.tsx
@@ -1,60 +1,256 @@
-import { format, isToday, isTomorrow } from "date-fns";
+import { useState } from "react";
+import { format, isToday, isTomorrow, addDays, startOfDay } from "date-fns";
 import { CheckSquare, Bell } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import {
+  DndContext,
+  DragOverlay,
+  MouseSensor,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
 import type { UpcomingItem } from "@/lib/dashboardStats";
+import { useTodoStore } from "@/zustand/todoStore";
 
 interface UpcomingAgendaProps {
   items: UpcomingItem[];
-  limit?: number;
 }
 
-const formatWhen = (date: Date): string => {
-  if (isToday(date)) return "Today";
-  if (isTomorrow(date)) return "Tomorrow";
-  return format(date, "EEE, MMM d");
+// Maps a column key to the new due date when a todo is dropped there
+function targetDate(columnKey: string): Date | null {
+  const today = startOfDay(new Date());
+  if (columnKey === "today") return today;
+  if (columnKey === "tomorrow") return addDays(today, 1);
+  if (columnKey === "later") return addDays(today, 7);
+  return null; // "overdue" is not a valid drop target
+}
+
+const formatTime = (item: UpcomingItem): string => {
+  if (item.meta) return item.meta;
+  return format(item.date, "HH:mm");
 };
 
-export function UpcomingAgenda({ items, limit = 7 }: UpcomingAgendaProps) {
+// ── Card ─────────────────────────────────────────────────────────────────────
+
+function KanbanCard({
+  item,
+  dragging = false,
+}: {
+  item: UpcomingItem;
+  dragging?: boolean;
+}) {
+  const Icon = item.type === "todo" ? CheckSquare : Bell;
+  return (
+    <div
+      className={`flex flex-col gap-1 rounded-lg border border-white/10 bg-white/5 px-3 py-2 ${
+        item.type === "todo" ? "cursor-grab active:cursor-grabbing" : ""
+      } ${dragging ? "shadow-2xl shadow-black/60 ring-1 ring-white/20" : ""}`}
+    >
+      <div className="flex items-start gap-2">
+        <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-white/40" />
+        <p className="text-xs font-medium leading-snug text-white">
+          {item.title}
+        </p>
+      </div>
+      <div className="flex items-center justify-between pl-5">
+        <span className="text-[11px] text-white/40">{formatTime(item)}</span>
+        <Badge
+          variant={item.overdue ? "destructive" : "secondary"}
+          className="h-4 px-1.5 text-[10px] capitalize"
+        >
+          {item.type === "todo" ? "todo" : "reminder"}
+        </Badge>
+      </div>
+    </div>
+  );
+}
+
+// ── Draggable wrapper (todos only) ────────────────────────────────────────────
+
+function DraggableTodoCard({ item }: { item: UpcomingItem }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: item.id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        opacity: isDragging ? 0 : 1,
+        touchAction: "none",
+      }}
+      {...attributes}
+      {...listeners}
+    >
+      <KanbanCard item={item} />
+    </div>
+  );
+}
+
+// ── Droppable column ──────────────────────────────────────────────────────────
+
+interface ColDef {
+  key: string;
+  label: string;
+  accent: string;
+  headerBg: string;
+  borderColor: string;
+  ringColor: string;
+  items: UpcomingItem[];
+}
+
+function DroppableKanbanColumn({ col }: { col: ColDef }) {
+  const droppable = col.key !== "overdue";
+  const { setNodeRef, isOver } = useDroppable({
+    id: col.key,
+    disabled: !droppable,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex min-w-0 flex-1 flex-col rounded-xl border ${col.borderColor} bg-white/3 overflow-hidden transition-shadow duration-150 ${
+        isOver && droppable ? `ring-2 ring-inset ${col.ringColor}` : ""
+      }`}
+    >
+      <div
+        className={`flex items-center justify-between px-3 py-2.5 ${col.headerBg}`}
+      >
+        <span
+          className={`text-xs font-semibold uppercase tracking-wider ${col.accent}`}
+        >
+          {col.label}
+        </span>
+        <span
+          className={`flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${col.accent} bg-white/10`}
+        >
+          {col.items.length}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2 p-2 min-h-[60px]">
+        {col.items.length === 0 ? (
+          <p className="py-4 text-center text-[11px] text-white/30">
+            All clear
+          </p>
+        ) : (
+          col.items.map((item) =>
+            item.type === "todo" ? (
+              <DraggableTodoCard key={item.id} item={item} />
+            ) : (
+              <KanbanCard key={item.id} item={item} />
+            ),
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Root ──────────────────────────────────────────────────────────────────────
+
+export function UpcomingAgenda({ items }: UpcomingAgendaProps) {
+  const { updateTodo } = useTodoStore();
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 5 },
+    }),
+  );
+
+  const activeItem = activeId ? items.find((i) => i.id === activeId) : null;
+
+  function handleDragStart({ active }: DragStartEvent) {
+    setActiveId(String(active.id));
+  }
+
+  function handleDragEnd({ active, over }: DragEndEvent) {
+    setActiveId(null);
+    if (!over) return;
+    const item = items.find((i) => i.id === String(active.id));
+    if (!item || item.type !== "todo") return;
+    const newDate = targetDate(String(over.id));
+    if (!newDate) return;
+    const todoId = Number(String(active.id).replace("todo-", ""));
+    updateTodo(todoId, { dueDate: newDate });
+  }
+
+  const columns: ColDef[] = [
+    {
+      key: "overdue",
+      label: "Overdue",
+      accent: "text-red-400",
+      headerBg: "bg-red-500/10",
+      borderColor: "border-red-500/20",
+      ringColor: "ring-red-400/40",
+      items: items.filter((i) => i.overdue),
+    },
+    {
+      key: "today",
+      label: "Today",
+      accent: "text-amber-400",
+      headerBg: "bg-amber-500/10",
+      borderColor: "border-amber-500/20",
+      ringColor: "ring-amber-400/40",
+      items: items.filter((i) => !i.overdue && isToday(i.date)),
+    },
+    {
+      key: "tomorrow",
+      label: "Tomorrow",
+      accent: "text-sky-400",
+      headerBg: "bg-sky-500/10",
+      borderColor: "border-sky-500/20",
+      ringColor: "ring-sky-400/40",
+      items: items.filter((i) => !i.overdue && isTomorrow(i.date)),
+    },
+    {
+      key: "later",
+      label: "Upcoming",
+      accent: "text-white/60",
+      headerBg: "bg-white/5",
+      borderColor: "border-white/10",
+      ringColor: "ring-white/30",
+      items: items.filter(
+        (i) => !i.overdue && !isToday(i.date) && !isTomorrow(i.date),
+      ),
+    },
+  ];
+
   if (items.length === 0) {
     return (
-      <div className="py-8 text-center text-sm text-white/50">
-        Nothing upcoming, you're all caught up. 🎉
-      </div>
+      <p className="py-8 text-center text-sm text-white/50">
+        Nothing upcoming — you're all caught up. 🎉
+      </p>
     );
   }
 
-  const visible = items.slice(0, limit);
-
   return (
-    <ul className="space-y-2">
-      {visible.map((item) => {
-        const Icon = item.type === "todo" ? CheckSquare : Bell;
-        return (
-          <li
-            key={item.id}
-            className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 px-3 py-2"
-          >
-            <Icon className="h-4 w-4 shrink-0 text-white/50" />
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-sm text-white">{item.title}</p>
-              <p className="text-xs text-white/50">
-                {formatWhen(item.date)}
-                {item.type === "reminder" && item.meta ? ` · ${item.meta}` : ""}
-                {item.type === "todo" && item.meta ? ` · ${item.meta}` : ""}
-              </p>
-            </div>
-            {item.overdue ? (
-              <Badge variant="destructive" className="shrink-0 text-xs">
-                Overdue
-              </Badge>
-            ) : (
-              <Badge variant="secondary" className="shrink-0 text-xs capitalize">
-                {item.type}
-              </Badge>
-            )}
-          </li>
-        );
-      })}
-    </ul>
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex gap-3 overflow-x-auto pb-1">
+        {columns.map((col) => (
+          <DroppableKanbanColumn key={col.key} col={col} />
+        ))}
+      </div>
+
+      <DragOverlay dropAnimation={{ duration: 150, easing: "ease" }}>
+        {activeItem && (
+          <div className="rotate-1 scale-105 pointer-events-none w-48">
+            <KanbanCard item={activeItem} dragging />
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
   );
 }

--- a/src/componenets/HabitTracker/Habit.tsx
+++ b/src/componenets/HabitTracker/Habit.tsx
@@ -31,7 +31,7 @@ export default function HabitComponenet({ habit }: { habit: Habit }) {
         {/* Desktop Layout */}
         <div className="hidden md:grid grid-cols-[1fr_auto_auto_auto] gap-4 items-center">
           <div>
-            <h3 className="font-medium text-foreground text-balance">
+            <h3 className="font-medium text-white text-balance">
               {habit.name}
             </h3>
           </div>
@@ -45,7 +45,7 @@ export default function HabitComponenet({ habit }: { habit: Habit }) {
                   "w-8 h-8 rounded-full border-2 transition-all duration-200 hover:scale-110 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1",
                   completed
                     ? "bg-primary border-primary shadow-md"
-                    : "bg-background border-border hover:border-muted-foreground",
+                    : "bg-white/5 border-white/15 hover:border-white/40",
                 )}
                 aria-label={`${DAYS_OF_WEEK[index]} - ${completed ? `Completed` : `Not completed`}`}
               >
@@ -59,7 +59,7 @@ export default function HabitComponenet({ habit }: { habit: Habit }) {
           </div>
 
           <div className="w-16 text-center">
-            <span className="text-sm font-medium text-muted-foreground">
+            <span className="text-sm font-medium text-white/60">
               {getCompletionRate(habit)}%
             </span>
           </div>
@@ -68,7 +68,7 @@ export default function HabitComponenet({ habit }: { habit: Habit }) {
             variant="ghost"
             size="sm"
             onClick={() => deleteHabit(habit.id)}
-            className="w-10 h-10 p-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+            className="w-10 h-10 p-0 text-white/60 hover:text-destructive hover:bg-destructive/10"
           >
             <Trash2 className="w-4 h-4" />
           </Button>
@@ -77,18 +77,18 @@ export default function HabitComponenet({ habit }: { habit: Habit }) {
         {/* Mobile Layout */}
         <div className="md:hidden space-y-3">
           <div className="flex justify-between items-start">
-            <h3 className="font-medium text-foreground text-balance flex-1 pr-2">
+            <h3 className="font-medium text-white text-balance flex-1 pr-2">
               {habit.name}
             </h3>
             <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-muted-foreground">
+              <span className="text-sm font-medium text-white/60">
                 {getCompletionRate(habit)}%
               </span>
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={() => deleteHabit(habit.id)}
-                className="w-8 h-8 p-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10 flex-shrink-0"
+                className="w-8 h-8 p-0 text-white/60 hover:text-destructive hover:bg-destructive/10 flex-shrink-0"
               >
                 <Trash2 className="w-3 h-3" />
               </Button>
@@ -96,7 +96,7 @@ export default function HabitComponenet({ habit }: { habit: Habit }) {
           </div>
 
           <div className="space-y-2">
-            <div className="grid grid-cols-7 gap-1 text-xs text-muted-foreground text-center">
+            <div className="grid grid-cols-7 gap-1 text-xs text-white/60 text-center">
               {DAYS_OF_WEEK.map((day) => (
                 <div key={day} className="font-medium">
                   {day}
@@ -112,7 +112,7 @@ export default function HabitComponenet({ habit }: { habit: Habit }) {
                     "w-full aspect-square rounded-full border-2 transition-all duration-200 hover:scale-110 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1",
                     completed
                       ? "bg-primary border-primary shadow-md"
-                      : "bg-background border-border hover:border-muted-foreground",
+                      : "bg-white/5 border-white/15 hover:border-white/40",
                   )}
                   aria-label={`${DAYS_OF_WEEK[index]} - ${completed ? `Completed` : `Not completed`}`}
                 >

--- a/src/componenets/ModeSelection.tsx
+++ b/src/componenets/ModeSelection.tsx
@@ -41,7 +41,7 @@ export function ModeSelection() {
   if (isLoading) {
     return (
       <div className="w-full max-w-sm">
-        <div className="animate-pulse bg-gray-200 h-10 rounded-md"></div>
+        <div className="animate-pulse bg-white/10 h-10 rounded-md"></div>
       </div>
     );
   }
@@ -53,12 +53,12 @@ export function ModeSelection() {
         onValueChange={handleModeChange}
         className="w-full"
       >
-        <TabsList className="grid w-full grid-cols-3">
+        <TabsList className="grid w-full grid-cols-3 bg-white/15 text-white">
           {availableModes.map((mode) => (
             <TabsTrigger
               key={mode.name}
               value={mode.name || ""}
-              className="text-xs md:text-sm data-[state=active]:shadow-lg data-[state=active]:shadow-black/80"
+              className="text-xs md:text-sm text-white/60 data-[state=active]:bg-white/30 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-black/80"
             >
               {mode.name}
             </TabsTrigger>

--- a/src/componenets/Modes.tsx
+++ b/src/componenets/Modes.tsx
@@ -31,23 +31,23 @@ export function Mode({ title, details, time }: Props) {
       flex items-center space-x-3 p-4 rounded-lg border transition-all duration-200 cursor-pointer
       ${
         isSelected
-          ? "border-primary bg-primary/5 shadow-sm"
-          : "border-border bg-background hover:bg-muted/50 hover:border-muted-foreground/20"
+          ? "border-white/40 bg-white/10 shadow-sm"
+          : "border-white/15 bg-white/5 hover:bg-white/10 hover:border-white/30"
       }
       `}
       onClick={setContextMode}
     >
       <div
-        className={`w-4 h-4 rounded-full border-2 shrink-0 ${isSelected ? "bg-primary border-primary" : "border-muted-foreground"}`}
+        className={`w-4 h-4 rounded-full border-2 shrink-0 ${isSelected ? "bg-white border-white" : "border-white/40"}`}
       />
       <div className="flex-1 cursor-pointer">
         <div className="space-y-1">
           <div
-            className={`font-medium ${isSelected ? "text-primary" : "text-foreground"}`}
+            className={`font-medium ${isSelected ? "text-white" : "text-white/80"}`}
           >
             {title}
           </div>
-          <div className="text-xs text-muted-foreground font-mono">
+          <div className="text-xs text-white/60 font-mono">
             {displayDetails}
           </div>
         </div>

--- a/src/componenets/Reminder/ReminderCard.tsx
+++ b/src/componenets/Reminder/ReminderCard.tsx
@@ -31,7 +31,7 @@ export function ReminderCard({
     return (
       <div
         className={cn(
-          "bg-card border rounded-md p-2 transition-all duration-200 hover:shadow-sm",
+          "bg-white/5 border border-white/10 rounded-md p-2 transition-all duration-200 hover:bg-white/10",
           reminder.completed && "opacity-60",
         )}
       >
@@ -44,14 +44,14 @@ export function ReminderCard({
           <div className="flex-1 min-w-0">
             <p
               className={cn(
-                "text-sm font-medium text-card-foreground truncate",
+                "text-sm font-medium text-white truncate",
                 reminder.completed && "line-through",
               )}
             >
               {reminder.title}
             </p>
             <div className="flex items-center gap-2 mt-1">
-              <span className="text-xs text-muted-foreground">
+              <span className="text-xs text-white/60">
                 {reminder.time}
               </span>
               <Badge
@@ -76,7 +76,7 @@ export function ReminderCard({
   return (
     <div
       className={cn(
-        "bg-card border rounded-lg p-4 transition-all duration-200 hover:shadow-sm",
+        "bg-white/5 border border-white/10 rounded-lg p-4 transition-all duration-200 hover:bg-white/10",
         reminder.completed && "opacity-60",
       )}
     >
@@ -92,7 +92,7 @@ export function ReminderCard({
             <div className="flex items-center gap-2">
               <h3
                 className={cn(
-                  "font-medium text-card-foreground leading-tight",
+                  "font-medium text-white leading-tight",
                   reminder.completed && "line-through",
                 )}
               >
@@ -118,7 +118,7 @@ export function ReminderCard({
           {reminder.description && (
             <p
               className={cn(
-                "text-sm text-muted-foreground mb-3 leading-relaxed",
+                "text-sm text-white/60 mb-3 leading-relaxed",
                 reminder.completed && "line-through",
               )}
             >
@@ -127,7 +127,7 @@ export function ReminderCard({
           )}
 
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <div className="flex items-center gap-1 text-xs text-white/60">
               <Clock className="w-3 h-3" />
               <span>{reminder.time}</span>
             </div>

--- a/src/componenets/Sidebar.tsx
+++ b/src/componenets/Sidebar.tsx
@@ -37,14 +37,14 @@ export function Sidebar() {
 
   return (
     <aside
-      className={`${isCollapsed ? "w-16" : "w-64"} h-screen border-r bg-background transition-all duration-300 ease-in-out relative flex flex-col`}
+      className={`${isCollapsed ? "w-16" : "w-64"} h-screen bg-transparent text-white transition-all duration-300 ease-in-out relative flex flex-col`}
     >
       {/* Toggle Button on Border - Desktop only */}
       <Button
         variant="ghost"
         size="icon"
         onClick={toggleSidebar}
-        className="hidden md:flex absolute -right-3 top-6 h-6 w-6 rounded-full border bg-background shadow-md hover:shadow-lg z-10"
+        className="hidden md:flex absolute -right-3 top-6 h-6 w-6 rounded-full border border-white/20 bg-[#00091d] text-white hover:bg-white/10 shadow-md hover:shadow-lg z-10"
       >
         {isCollapsed ? (
           <ChevronRight className="h-3 w-3" />

--- a/src/componenets/StatusHeader.tsx
+++ b/src/componenets/StatusHeader.tsx
@@ -19,19 +19,19 @@ function TimeBadge({
   return (
     <Badge
       variant="secondary"
-      className="flex flex-col items-center gap-1  text-sm px-3 py-2"
+      className="flex flex-col items-center gap-1 text-sm px-3 py-2 bg-white/5 border border-white/10 text-white"
     >
       <h3 className="text-xs">{label}</h3>
       <div className="flex items-center gap-1">
         <Button
-          className="rounded-full w-6 h-6 p-0 bg-transparent text-lg text-black hover:text-white"
+          className="rounded-full w-6 h-6 p-0 bg-transparent text-lg text-white/70 hover:text-white hover:bg-white/10"
           onClick={onDecrease}
         >
           <Minus />
         </Button>
         <span className="text-sm">{milliSecToMin(value)}</span>
         <Button
-          className="rounded-full w-6 h-6 p-0 bg-transparent text-lg text-black hover:text-white"
+          className="rounded-full w-6 h-6 p-0 bg-transparent text-lg text-white/70 hover:text-white hover:bg-white/10"
           onClick={onIncrease}
         >
           <Plus />

--- a/src/componenets/TodoList/Todo.tsx
+++ b/src/componenets/TodoList/Todo.tsx
@@ -56,7 +56,7 @@ export default function TodoComponent({
   const StatusIcon = statusConfig.icon;
 
   return (
-    <div className="group relative overflow-hidden rounded-2xl bg-gradient-to-br bg-white border border-slate-200/60 shadow-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02] p-3">
+    <div className="group relative overflow-hidden rounded-2xl bg-white/5 border border-white/10 backdrop-blur-sm shadow-sm hover:bg-white/10 hover:shadow-lg transition-all duration-300 hover:scale-[1.02] p-3">
       <div
         className={`absolute top-3 right-3 w-2 h-2 rounded-full ${statusConfig.dot} opacity-60`}
       />
@@ -67,7 +67,7 @@ export default function TodoComponent({
           onChange={(e) => setTitle(e.target.value)}
           onBlur={handleUpdate}
           placeholder="Task title..."
-          className="border-0 bg-transparent p-0 text-base font-medium text-slate-800 placeholder:text-slate-400 focus-visible:ring-0 h-auto"
+          className="border-0 bg-transparent p-0 text-base font-medium text-white placeholder:text-white/40 focus-visible:ring-0 h-auto"
         />
 
         <Textarea
@@ -75,7 +75,7 @@ export default function TodoComponent({
           onChange={(e) => setDescription(e.target.value)}
           onBlur={handleUpdate}
           placeholder="Add details..."
-          className="border-0 bg-transparent p-0 text-sm text-slate-600 placeholder:text-slate-400 focus-visible:ring-0 resize-none min-h-0"
+          className="border-0 bg-transparent p-0 text-sm text-white/70 placeholder:text-white/40 focus-visible:ring-0 resize-none min-h-0"
           rows={1}
         />
       </div>
@@ -132,7 +132,7 @@ export default function TodoComponent({
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 px-2 text-xs text-slate-600 hover:text-slate-800 hover:bg-slate-100/80"
+              className="h-7 px-2 text-xs text-white/70 hover:text-white hover:bg-white/10"
             >
               <CalendarIcon className="mr-1 h-3 w-3" />
               {dueDate ? format(dueDate, "MMM d") : "Date"}
@@ -156,7 +156,7 @@ export default function TodoComponent({
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 w-7 p-0 text-slate-400 hover:text-red-500 hover:bg-red-50 opacity-0 group-hover:opacity-100 transition-all duration-200"
+              className="h-7 w-7 p-0 text-white/40 hover:text-red-400 hover:bg-red-500/10 opacity-0 group-hover:opacity-100 transition-all duration-200"
             >
               <Trash className="h-3 w-3" />
             </Button>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-white/5 text-white flex flex-col gap-6 rounded-xl border border-white/10 backdrop-blur-sm py-6 shadow-sm",
         className
       )}
       {...props}
@@ -42,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-white/60 text-sm", className)}
       {...props}
     />
   )

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -22,5 +22,6 @@ export const REMINDER_PRIORITY_COLORS = {
   high: "bg-red-400",
 };
 
-export const API_BASE_URL = "https://zendoro-backend.onrender.com";
+export const API_BASE_URL =
+  import.meta.env.VITE_API_URL ?? "https://zendoro-backend.onrender.com";
 export const LS_ZENDORO_AUTH = "zendoro-auth-token";

--- a/src/index.css
+++ b/src/index.css
@@ -224,6 +224,9 @@
 @layer components {
   .gradient-button {
     @apply relative appearance-none cursor-pointer;
+    /* Brighter border so the button stands out on the dark background */
+    --border-color-1: rgba(255, 255, 255, 0.7);
+    --border-color-2: rgba(255, 255, 255, 0.95);
     background: radial-gradient(
       var(--spread-x) var(--spread-y) at var(--pos-x) var(--pos-y),
       var(--color-1) var(--stop-1),
@@ -281,8 +284,8 @@
     --color-4: #37140a;
     --color-5: #000;
     --border-angle: 190deg;
-    --border-color-1: hsla(340, 78%, 90%, 0.1);
-    --border-color-2: hsla(340, 75%, 90%, 0.6);
+    --border-color-1: rgba(255, 255, 255, 0.8);
+    --border-color-2: rgba(255, 255, 255, 1);
     --stop-1: 0%;
     --stop-2: 8.8%;
     --stop-3: 21.44%;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -18,13 +18,13 @@ const RootLayout = () => {
       <div className="absolute inset-0 -z-10 bg-[#000000] bg-[radial-gradient(#ffffff33_1px,#00091d_1px)] bg-[size:20px_20px]"></div>
 
       {/* Mobile Header */}
-      <div className="md:hidden fixed top-0 left-0 right-0 z-30 bg-white shadow-sm border-b">
+      <div className="md:hidden fixed top-0 left-0 right-0 z-30 bg-white/5 backdrop-blur-md shadow-sm border-b border-white/10 text-white">
         <div className="flex items-center justify-between p-3">
           <Button
             variant="ghost"
             size="icon"
             onClick={() => useSidebarStore.getState().toggleSidebar()}
-            className="h-8 w-8"
+            className="h-8 w-8 text-white hover:bg-white/10"
           >
             <Menu className="h-4 w-4" />
           </Button>
@@ -37,14 +37,14 @@ const RootLayout = () => {
       <div className="flex w-full h-full pt-14 md:pt-0">
         {/* Desktop/Tablet Sidebar */}
         <div
-          className={`hidden md:block ${isCollapsed ? "w-16" : "w-64"} bg-white rounded-r-2xl shadow-md transition-all duration-300 ease-in-out`}
+          className={`hidden md:block ${isCollapsed ? "w-16" : "w-64"} bg-white/5 backdrop-blur-md border-r border-white/10 rounded-r-2xl shadow-md transition-all duration-300 ease-in-out`}
         >
           <Sidebar />
         </div>
 
         {/* Mobile Sidebar - Overlay */}
         <div
-          className={`md:hidden fixed inset-y-0 left-0 z-50 ${isCollapsed ? "-translate-x-full" : "translate-x-0"} w-64 bg-white shadow-xl transition-transform duration-300 ease-in-out pt-14`}
+          className={`md:hidden fixed inset-y-0 left-0 z-50 ${isCollapsed ? "-translate-x-full" : "translate-x-0"} w-64 bg-[#00091d]/95 backdrop-blur-md border-r border-white/10 shadow-xl transition-transform duration-300 ease-in-out pt-14`}
         >
           <Sidebar />
         </div>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -37,7 +37,7 @@ const RootLayout = () => {
       <div className="flex w-full h-full pt-14 md:pt-0">
         {/* Desktop/Tablet Sidebar */}
         <div
-          className={`hidden md:block ${isCollapsed ? "w-16" : "w-64"} bg-white/5 backdrop-blur-md border-r border-white/10 rounded-r-2xl shadow-md transition-all duration-300 ease-in-out`}
+          className={`hidden md:block relative z-10 ${isCollapsed ? "w-16" : "w-64"} bg-white/5 backdrop-blur-md border-r border-white/10 rounded-r-2xl shadow-md transition-all duration-300 ease-in-out`}
         >
           <Sidebar />
         </div>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -13,7 +13,7 @@ const RootLayout = () => {
   useDocumentTitle("Zendoro");
 
   return (
-    <main className="w-full min-h-screen relative overflow-x-hidden">
+    <main className="w-full h-screen relative overflow-hidden">
       {/* Background */}
       <div className="absolute inset-0 -z-10 bg-[#000000] bg-[radial-gradient(#ffffff33_1px,#00091d_1px)] bg-[size:20px_20px]"></div>
 
@@ -57,7 +57,7 @@ const RootLayout = () => {
           />
         )}
 
-        <div className="flex-1 overflow-x-hidden overflow-y-hidden transition-all duration-300 ease-in-out">
+        <div className="flex-1 overflow-x-hidden overflow-y-auto transition-all duration-300 ease-in-out">
           <Outlet />
         </div>
       </div>

--- a/src/routes/agent.tsx
+++ b/src/routes/agent.tsx
@@ -247,18 +247,18 @@ function RouteComponent() {
   };
 
   return (
-    <div className="flex h-screen flex-col bg-background">
+    <div className="flex h-screen flex-col bg-transparent">
       {/* Header */}
-      <header className="border-b border-border bg-card px-6 py-4">
+      <header className="border-b border-white/10 bg-white/5 backdrop-blur-sm px-6 py-4">
         <div className="mx-auto flex max-w-4xl items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary">
             <Bot className="h-6 w-6 text-primary-foreground" />
           </div>
           <div>
-            <h1 className="text-lg font-semibold text-foreground">
+            <h1 className="text-lg font-semibold text-white">
               AI Assistant
             </h1>
-            <p className="text-sm text-muted-foreground">Always here to help</p>
+            <p className="text-sm text-white/60">Always here to help</p>
           </div>
         </div>
       </header>
@@ -275,7 +275,7 @@ function RouteComponent() {
                 <AvatarFallback
                   className={
                     message.role === "user"
-                      ? "bg-secondary text-secondary-foreground"
+                      ? "bg-white/10 text-white"
                       : "bg-primary text-primary-foreground"
                   }
                 >
@@ -293,7 +293,7 @@ function RouteComponent() {
                   className={`rounded-2xl px-4 py-3 ${
                     message.role === "user"
                       ? "bg-primary text-primary-foreground"
-                      : "bg-muted text-foreground"
+                      : "bg-white/10 text-white"
                   }`}
                 >
                   <div className="max-h-[48vh] overflow-auto whitespace-pre-wrap break-words">
@@ -322,14 +322,14 @@ function RouteComponent() {
                           const isInline = !className;
                           return isInline ? (
                             <code
-                              className="rounded bg-background/50 px-1.5 py-0.5 font-mono text-xs"
+                              className="rounded bg-white/10 px-1.5 py-0.5 font-mono text-xs"
                               {...props}
                             >
                               {children}
                             </code>
                           ) : (
                             <code
-                              className="block rounded-lg bg-background/50 p-3 font-mono text-xs overflow-x-auto"
+                              className="block rounded-lg bg-white/10 p-3 font-mono text-xs overflow-x-auto"
                               {...props}
                             >
                               {children}
@@ -367,7 +367,7 @@ function RouteComponent() {
                           <h3 className="mb-2 text-sm font-bold">{children}</h3>
                         ),
                         blockquote: ({ children }) => (
-                          <blockquote className="border-l-2 border-foreground/20 pl-3 italic">
+                          <blockquote className="border-l-2 border-white/20 pl-3 italic">
                             {children}
                           </blockquote>
                         ),
@@ -377,7 +377,7 @@ function RouteComponent() {
                     </ReactMarkdown>
                   </div>
                 </div>
-                <span className="text-xs text-muted-foreground">
+                <span className="text-xs text-white/60">
                   {message.timestamp.toLocaleTimeString([], {
                     hour: "2-digit",
                     minute: "2-digit",
@@ -394,10 +394,10 @@ function RouteComponent() {
                   <Bot className="h-4 w-4" />
                 </AvatarFallback>
               </Avatar>
-              <div className="flex items-center gap-1 rounded-2xl bg-muted px-4 py-3">
-                <div className="h-2 w-2 animate-bounce rounded-full bg-foreground/60 [animation-delay:-0.3s]" />
-                <div className="h-2 w-2 animate-bounce rounded-full bg-foreground/60 [animation-delay:-0.15s]" />
-                <div className="h-2 w-2 animate-bounce rounded-full bg-foreground/60" />
+              <div className="flex items-center gap-1 rounded-2xl bg-white/10 px-4 py-3">
+                <div className="h-2 w-2 animate-bounce rounded-full bg-white/60 [animation-delay:-0.3s]" />
+                <div className="h-2 w-2 animate-bounce rounded-full bg-white/60 [animation-delay:-0.15s]" />
+                <div className="h-2 w-2 animate-bounce rounded-full bg-white/60" />
               </div>
             </div>
           )}
@@ -405,7 +405,7 @@ function RouteComponent() {
       </ScrollArea>
 
       {/* Input Area */}
-      <div className="border-t border-border bg-card px-4 py-4">
+      <div className="border-t border-white/10 bg-white/5 backdrop-blur-sm px-4 py-4">
         <div className="mx-auto flex max-w-4xl gap-2">
           <Input
             ref={inputRef}
@@ -413,7 +413,7 @@ function RouteComponent() {
             onChange={(e) => setInput(e.target.value)}
             onKeyPress={handleKeyPress}
             placeholder="Type your message..."
-            className="flex-1 bg-background"
+            className="flex-1 bg-white/5 text-white placeholder:text-white/40"
             disabled={isTyping}
           />
           <Button
@@ -426,7 +426,7 @@ function RouteComponent() {
             <span className="sr-only">Send message</span>
           </Button>
         </div>
-        <p className="mx-auto mt-2 max-w-4xl text-center text-xs text-muted-foreground">
+        <p className="mx-auto mt-2 max-w-4xl text-center text-xs text-white/60">
           AI can make mistakes. Consider checking important information.
         </p>
       </div>

--- a/src/routes/habit-tracker.tsx
+++ b/src/routes/habit-tracker.tsx
@@ -64,7 +64,7 @@ function RouteComponent() {
       <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
         <div className="max-w-4xl mx-auto p-3 md:p-6 space-y-4 md:space-y-6">
           <div className="text-center space-y-2">
-            <h1 className="text-2xl md:text-4xl font-bold text-foreground">
+            <h1 className="text-2xl md:text-4xl font-bold text-white">
               Habit Tracker
             </h1>
             <p className="text-red-500 text-base md:text-lg">Error: {error}</p>
@@ -83,10 +83,10 @@ function RouteComponent() {
       <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
         <div className="max-w-4xl mx-auto p-3 md:p-6 space-y-4 md:space-y-6">
           <div className="text-center space-y-2">
-            <h1 className="text-2xl md:text-4xl font-bold text-foreground">
+            <h1 className="text-2xl md:text-4xl font-bold text-white">
               Habit Tracker
             </h1>
-            <p className="text-muted-foreground text-base md:text-lg">
+            <p className="text-white/60 text-base md:text-lg">
               Loading your habits...
             </p>
           </div>
@@ -94,7 +94,7 @@ function RouteComponent() {
             {[1, 2, 3].map((i) => (
               <div
                 key={i}
-                className="animate-pulse bg-gray-200 h-16 rounded-md"
+                className="animate-pulse bg-white/10 h-16 rounded-md"
               ></div>
             ))}
           </div>
@@ -107,10 +107,10 @@ function RouteComponent() {
     <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
       <div className="max-w-4xl mx-auto p-3 md:p-6 space-y-4 md:space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl md:text-4xl font-bold text-foreground">
+          <h1 className="text-2xl md:text-4xl font-bold text-white">
             Habit Tracker
           </h1>
-          <p className="text-muted-foreground text-base md:text-lg">
+          <p className="text-white/60 text-base md:text-lg">
             Build better habits, one day at a time
           </p>
         </div>
@@ -148,18 +148,18 @@ function RouteComponent() {
 
         {/* Days of week header - Desktop only */}
         <div className="hidden md:grid grid-cols-[1fr_auto_auto_auto] gap-4 px-4">
-          <div className="text-sm font-medium text-muted-foreground">Habit</div>
+          <div className="text-sm font-medium text-white/60">Habit</div>
           <div className="grid grid-cols-7 gap-2">
             {DAYS_OF_WEEK.map((day) => (
               <div
                 key={day}
-                className="w-8 text-center text-sm font-medium text-muted-foreground"
+                className="w-8 text-center text-sm font-medium text-white/60"
               >
                 {day}
               </div>
             ))}
           </div>
-          <div className="w-16 text-center text-sm font-medium text-muted-foreground">
+          <div className="w-16 text-center text-sm font-medium text-white/60">
             Progress
           </div>
           <div className="w-10"></div>
@@ -175,7 +175,7 @@ function RouteComponent() {
         {habits.length === 0 && (
           <Card>
             <CardContent className="p-8 text-center">
-              <p className="text-muted-foreground text-lg">
+              <p className="text-white/60 text-lg">
                 No habits yet. Add your first habit above to get started!
               </p>
             </CardContent>

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -194,11 +194,11 @@ function LoginComponent() {
           </CardContent>
 
           <CardFooter className="flex flex-col space-y-4 pt-0">
-            <div className="text-center text-sm text-muted-foreground">
+            <div className="text-center text-sm text-white/60">
               Don't have an account?{" "}
               <Link
                 to="/signup"
-                className="font-medium text-primary hover:underline"
+                className="font-medium text-white hover:underline"
               >
                 Sign up here
               </Link>

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -270,11 +270,11 @@ function SignupComponent() {
           </CardContent>
 
           <CardFooter className="flex flex-col space-y-4 pt-0">
-            <div className="text-center text-sm text-muted-foreground">
+            <div className="text-center text-sm text-white/60">
               Already have an account?{" "}
               <Link
                 to="/login"
-                className="font-medium text-primary hover:underline"
+                className="font-medium text-white hover:underline"
               >
                 Sign in here
               </Link>

--- a/src/routes/todo.tsx
+++ b/src/routes/todo.tsx
@@ -19,7 +19,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useTodoStore } from "@/zustand/todoStore";
+import {
+  DndContext,
+  DragOverlay,
+  MouseSensor,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import { useTodoStore, type Todo } from "@/zustand/todoStore";
 import TodoComponent from "@/componenets/TodoList/Todo";
 import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { isAuthenticated } from "@/lib/authVerification";
@@ -29,12 +42,118 @@ export const Route = createFileRoute("/todo")({
   component: RouteComponent,
   beforeLoad: async () => {
     if (!isAuthenticated()) {
-      throw redirect({
-        to: "/login",
-      });
+      throw redirect({ to: "/login" });
     }
   },
 });
+
+type TodoStatus = Todo["status"];
+
+const COLUMNS: {
+  status: TodoStatus;
+  label: string;
+  accent: string;
+  headerBg: string;
+  borderColor: string;
+  ringColor: string;
+}[] = [
+  {
+    status: "TODO",
+    label: "TODO",
+    accent: "text-slate-400",
+    headerBg: "bg-slate-500/10",
+    borderColor: "border-slate-500/20",
+    ringColor: "ring-slate-400/40",
+  },
+  {
+    status: "In Progress",
+    label: "In Progress",
+    accent: "text-amber-400",
+    headerBg: "bg-amber-500/10",
+    borderColor: "border-amber-500/20",
+    ringColor: "ring-amber-400/40",
+  },
+  {
+    status: "Done",
+    label: "Done",
+    accent: "text-emerald-400",
+    headerBg: "bg-emerald-500/10",
+    borderColor: "border-emerald-500/20",
+    ringColor: "ring-emerald-400/40",
+  },
+  {
+    status: "Kill",
+    label: "Kill",
+    accent: "text-red-400",
+    headerBg: "bg-red-500/10",
+    borderColor: "border-red-500/20",
+    ringColor: "ring-red-400/40",
+  },
+];
+
+function DraggableCard({ todo }: { todo: Todo }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: String(todo.id) });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        opacity: isDragging ? 0 : 1,
+        touchAction: "none",
+      }}
+      {...attributes}
+      {...listeners}
+    >
+      <TodoComponent
+        id={todo.id}
+        title={todo.title}
+        description={todo.description}
+        dueDate={todo.dueDate}
+        status={todo.status}
+      />
+    </div>
+  );
+}
+
+function DroppableColumn({
+  col,
+  count,
+  children,
+}: {
+  col: (typeof COLUMNS)[number];
+  count: number;
+  children: React.ReactNode;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: col.status });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex flex-col rounded-xl border ${col.borderColor} bg-white/3 overflow-hidden transition-shadow duration-150 ${
+        isOver ? `ring-2 ring-inset ${col.ringColor}` : ""
+      }`}
+    >
+      <div
+        className={`flex items-center justify-between px-3 py-2.5 ${col.headerBg}`}
+      >
+        <span
+          className={`text-xs font-semibold uppercase tracking-wider ${col.accent}`}
+        >
+          {col.label}
+        </span>
+        <span
+          className={`flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${col.accent} bg-white/10`}
+        >
+          {count}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2 p-2 min-h-[80px]">{children}</div>
+    </div>
+  );
+}
 
 function RouteComponent() {
   useDocumentTitle("Todo List");
@@ -42,13 +161,36 @@ function RouteComponent() {
   const [open, setOpen] = useState(false);
   const [date, setDate] = useState<Date | undefined>(undefined);
   const [status, setStatus] = useState<string>("");
-  const { addTodo, todos, fetchTodos } = useTodoStore();
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const { addTodo, updateTodo, todos, fetchTodos } = useTodoStore();
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
     fetchTodos();
   }, [fetchTodos]);
 
-  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+  );
+
+  const activeTodo = activeId
+    ? todos.find((t) => String(t.id) === activeId)
+    : null;
+
+  function handleDragStart({ active }: DragStartEvent) {
+    setActiveId(String(active.id));
+  }
+
+  function handleDragEnd({ active, over }: DragEndEvent) {
+    setActiveId(null);
+    if (!over) return;
+    const newStatus = over.id as TodoStatus;
+    const todoId = Number(active.id);
+    const todo = todos.find((t) => t.id === todoId);
+    if (!todo || todo.status === newStatus) return;
+    updateTodo(todoId, { status: newStatus });
+  }
 
   function formHandler(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -63,10 +205,12 @@ function RouteComponent() {
 
     const errors: Record<string, string> = {};
     if (containsDangerousInput(title)) {
-      errors.title = "Invalid characters detected. HTML and scripts are not allowed.";
+      errors.title =
+        "Invalid characters detected. HTML and scripts are not allowed.";
     }
     if (description && containsDangerousInput(description)) {
-      errors.description = "Invalid characters detected. HTML and scripts are not allowed.";
+      errors.description =
+        "Invalid characters detected. HTML and scripts are not allowed.";
     }
     if (Object.keys(errors).length > 0) {
       setFormErrors(errors);
@@ -78,7 +222,7 @@ function RouteComponent() {
       title: title.trim(),
       description: description?.trim() || "",
       dueDate: date || null,
-      status: status as "TODO" | "In Progress" | "Done" | "Kill",
+      status: status as TodoStatus,
     });
 
     e.currentTarget.reset();
@@ -87,9 +231,12 @@ function RouteComponent() {
     setOpen(false);
   }
 
+  const byStatus = (s: TodoStatus) => todos.filter((t) => t.status === s);
+
   return (
     <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
-      <div className="max-w-2xl mx-auto mt-3 md:mt-6 space-y-3 md:space-y-4">
+      {/* Add task form */}
+      <div className="max-w-2xl mx-auto mb-6 md:mb-8">
         <form
           onSubmit={formHandler}
           className="relative overflow-hidden rounded-xl py-4 md:py-5"
@@ -108,7 +255,7 @@ function RouteComponent() {
                 name="title"
                 id="title"
                 required
-                className={`h-8 md:h-9 bg-white border-slate-200 focus:border-blue-400 focus:ring-blue-400/20 text-sm${formErrors.title ? " border-red-500" : ""}`}
+                className={`h-8 md:h-9 bg-white/5 border-white/15 text-white placeholder:text-white/40 focus:border-white/30 text-sm${formErrors.title ? " border-red-500" : ""}`}
               />
               {formErrors.title && (
                 <p className="text-xs text-red-400">{formErrors.title}</p>
@@ -127,7 +274,7 @@ function RouteComponent() {
                 placeholder="What should be done?"
                 maxLength={150}
                 id="description"
-                className={`h-8 md:h-9 bg-white border-slate-200 focus:border-blue-400 focus:ring-blue-400/20 text-sm resize-none${formErrors.description ? " border-red-500" : ""}`}
+                className={`h-8 md:h-9 bg-white/5 border-white/15 text-white placeholder:text-white/40 focus:border-white/30 text-sm resize-none${formErrors.description ? " border-red-500" : ""}`}
               />
               {formErrors.description && (
                 <p className="text-xs text-red-400">{formErrors.description}</p>
@@ -135,7 +282,7 @@ function RouteComponent() {
             </div>
 
             <div className="flex flex-col sm:flex-row gap-2 md:gap-3 sm:items-end">
-              <div className="flex-1 ">
+              <div className="flex-1">
                 <Label
                   htmlFor="date"
                   className="text-xs font-medium text-white uppercase tracking-wide"
@@ -148,7 +295,7 @@ function RouteComponent() {
                       variant="outline"
                       id="date"
                       type="button"
-                      className="h-8 md:h-9 w-full justify-between font-normal bg-white border-slate-200 hover:bg-white text-sm"
+                      className="h-8 md:h-9 w-full justify-between font-normal bg-white/5 border-white/15 text-white hover:bg-white/10 text-sm"
                     >
                       {date ? date.toLocaleDateString() : "Select date"}
                       <ChevronDownIcon className="h-3 w-3 opacity-70" />
@@ -162,8 +309,8 @@ function RouteComponent() {
                       mode="single"
                       selected={date}
                       captionLayout="dropdown"
-                      onSelect={(date) => {
-                        setDate(date);
+                      onSelect={(d) => {
+                        setDate(d);
                         setOpen(false);
                       }}
                     />
@@ -171,7 +318,7 @@ function RouteComponent() {
                 </Popover>
               </div>
 
-              <div className="flex-1 ">
+              <div className="flex-1">
                 <Label
                   htmlFor="status"
                   className="text-xs font-medium text-white uppercase tracking-wide"
@@ -180,7 +327,7 @@ function RouteComponent() {
                 </Label>
                 <Select value={status} onValueChange={setStatus} required>
                   <SelectTrigger
-                    className="h-8 md:h-9 w-full bg-white border-slate-200 hover:bg-white text-sm"
+                    className="h-8 md:h-9 w-full bg-white/5 border-white/15 text-white hover:bg-white/10 text-sm"
                     id="status"
                   >
                     <SelectValue placeholder="Select status" />
@@ -204,31 +351,47 @@ function RouteComponent() {
             </div>
           </div>
         </form>
-        {todos.length > 0 && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-2 px-1">
-              <div className="h-px bg-gradient-to-r from-transparent via-slate-300 to-transparent flex-1" />
-              <span className="text-xs font-medium text-slate-500 uppercase tracking-wider px-2">
-                Tasks ({todos.length})
-              </span>
-              <div className="h-px bg-gradient-to-r from-transparent via-slate-300 to-transparent flex-1" />
-            </div>
-
-            <div className="space-y-2">
-              {todos.map((todo) => (
-                <TodoComponent
-                  key={todo.id}
-                  id={todo.id}
-                  description={todo.description}
-                  title={todo.title}
-                  dueDate={todo.dueDate}
-                  status={todo.status}
-                />
-              ))}
-            </div>
-          </div>
-        )}
       </div>
+
+      {/* Kanban board */}
+      <DndContext
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {COLUMNS.map((col) => {
+            const items = byStatus(col.status);
+            return (
+              <DroppableColumn key={col.status} col={col} count={items.length}>
+                {items.length === 0 ? (
+                  <p className="py-6 text-center text-[11px] text-white/30">
+                    No tasks here
+                  </p>
+                ) : (
+                  items.map((todo) => (
+                    <DraggableCard key={todo.id} todo={todo} />
+                  ))
+                )}
+              </DroppableColumn>
+            );
+          })}
+        </div>
+
+        <DragOverlay dropAnimation={{ duration: 150, easing: "ease" }}>
+          {activeTodo && (
+            <div className="rotate-1 scale-105 shadow-2xl shadow-black/50 opacity-95 pointer-events-none">
+              <TodoComponent
+                id={activeTodo.id}
+                title={activeTodo.title}
+                description={activeTodo.description}
+                dueDate={activeTodo.dueDate}
+                status={activeTodo.status}
+              />
+            </div>
+          )}
+        </DragOverlay>
+      </DndContext>
     </div>
   );
 }

--- a/test-backend/Dockerfile
+++ b/test-backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+EXPOSE 3001
+CMD ["npm", "start"]

--- a/test-backend/index.js
+++ b/test-backend/index.js
@@ -1,0 +1,393 @@
+const express = require("express");
+const { Pool } = require("pg");
+const jwt = require("jsonwebtoken");
+const bcrypt = require("bcryptjs");
+const cors = require("cors");
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const pool = new Pool({
+  connectionString:
+    process.env.DATABASE_URL ||
+    "postgresql://postgres:postgres@localhost:5432/zendoro_test",
+});
+
+const JWT_SECRET = process.env.JWT_SECRET || "zendoro-test-secret";
+
+function auth(req, res, next) {
+  const header = req.headers.authorization;
+  if (!header) return res.status(401).json({ message: "No token" });
+  try {
+    const decoded = jwt.verify(header.split(" ")[1], JWT_SECRET);
+    req.userId = decoded.userId;
+    next();
+  } catch {
+    res.status(401).json({ message: "Invalid token" });
+  }
+}
+
+function todoRow(r) {
+  return {
+    id: r.id,
+    title: r.title,
+    description: r.description,
+    status: r.status,
+    dueDate: r.due_date,
+    userId: r.user_id,
+  };
+}
+
+function reminderRow(r) {
+  return {
+    id: r.id,
+    title: r.title,
+    description: r.description,
+    date: r.date ? r.date.toISOString().split("T")[0] : null,
+    time: r.time,
+    priority: r.priority,
+    completed: r.completed,
+    userId: r.user_id,
+  };
+}
+
+// ── Auth ─────────────────────────────────────────────────────────────────────
+
+app.post("/auth/login", async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const { rows } = await pool.query("SELECT * FROM users WHERE email = $1", [
+      email,
+    ]);
+    const user = rows[0];
+    if (!user || !bcrypt.compareSync(password, user.password)) {
+      return res.status(401).json({ message: "Invalid credentials" });
+    }
+    const token = jwt.sign({ userId: user.id }, JWT_SECRET, {
+      expiresIn: "7d",
+    });
+    res.json({
+      message: "Login successful",
+      user: { id: user.id, name: user.name, email: user.email },
+      token,
+    });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post("/auth/signup", async (req, res) => {
+  try {
+    const { name, email, password } = req.body;
+    const hashed = bcrypt.hashSync(password, 10);
+    const { rows } = await pool.query(
+      "INSERT INTO users (name, email, password) VALUES ($1, $2, $3) RETURNING id, name, email",
+      [name, email, hashed]
+    );
+    const user = rows[0];
+    const token = jwt.sign({ userId: user.id }, JWT_SECRET, {
+      expiresIn: "7d",
+    });
+    res.json({ message: "User created", user, token });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// ── Todos ─────────────────────────────────────────────────────────────────────
+
+app.get("/todo", auth, async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      "SELECT * FROM todos WHERE user_id = $1 ORDER BY created_at DESC",
+      [req.userId]
+    );
+    res.json(rows.map(todoRow));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post("/todo", auth, async (req, res) => {
+  try {
+    const { title, description, status, dueDate } = req.body;
+    const { rows } = await pool.query(
+      "INSERT INTO todos (title, description, status, due_date, user_id) VALUES ($1, $2, $3, $4, $5) RETURNING *",
+      [title, description, status || "TODO", dueDate || null, req.userId]
+    );
+    res.json(todoRow(rows[0]));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.put("/todo/:id", auth, async (req, res) => {
+  try {
+    const { title, description, status, dueDate } = req.body;
+    const { rows } = await pool.query(
+      `UPDATE todos SET
+        title = COALESCE($1, title),
+        description = COALESCE($2, description),
+        status = COALESCE($3, status),
+        due_date = COALESCE($4::timestamp, due_date)
+       WHERE id = $5 AND user_id = $6 RETURNING *`,
+      [title, description, status, dueDate || null, req.params.id, req.userId]
+    );
+    if (!rows[0]) return res.status(404).json({ message: "Not found" });
+    res.json(todoRow(rows[0]));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.delete("/todo/:id", auth, async (req, res) => {
+  try {
+    await pool.query("DELETE FROM todos WHERE id = $1 AND user_id = $2", [
+      req.params.id,
+      req.userId,
+    ]);
+    res.json({ message: "Deleted" });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// ── Habits ────────────────────────────────────────────────────────────────────
+
+app.get("/hobby", auth, async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      "SELECT * FROM hobbies WHERE user_id = $1",
+      [req.userId]
+    );
+    res.json(
+      rows.map((r) => ({ id: r.id, name: r.name, completions: r.completions }))
+    );
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post("/hobby", auth, async (req, res) => {
+  try {
+    const { name, completions } = req.body;
+    const { rows } = await pool.query(
+      "INSERT INTO hobbies (name, completions, user_id) VALUES ($1, $2, $3) RETURNING *",
+      [
+        name,
+        completions || [false, false, false, false, false, false, false],
+        req.userId,
+      ]
+    );
+    const r = rows[0];
+    res.json({ id: r.id, name: r.name, completions: r.completions });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.put("/hobby/:id", auth, async (req, res) => {
+  try {
+    const { name, completions } = req.body;
+    const { rows } = await pool.query(
+      `UPDATE hobbies SET
+        name = COALESCE($1, name),
+        completions = COALESCE($2, completions)
+       WHERE id = $3 AND user_id = $4 RETURNING *`,
+      [name, completions, req.params.id, req.userId]
+    );
+    if (!rows[0]) return res.status(404).json({ message: "Not found" });
+    const r = rows[0];
+    res.json({ id: r.id, name: r.name, completions: r.completions });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.delete("/hobby/:id", auth, async (req, res) => {
+  try {
+    await pool.query("DELETE FROM hobbies WHERE id = $1 AND user_id = $2", [
+      req.params.id,
+      req.userId,
+    ]);
+    res.json({ message: "Deleted" });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// ── Reminders ────────────────────────────────────────────────────────────────
+
+app.get("/reminder", auth, async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      "SELECT * FROM reminders WHERE user_id = $1 ORDER BY created_at DESC",
+      [req.userId]
+    );
+    res.json(rows.map(reminderRow));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post("/reminder", auth, async (req, res) => {
+  try {
+    const { title, description, date, time, priority, completed } = req.body;
+    const { rows } = await pool.query(
+      "INSERT INTO reminders (title, description, date, time, priority, completed, user_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *",
+      [
+        title,
+        description,
+        date || null,
+        time,
+        priority || "low",
+        completed || false,
+        req.userId,
+      ]
+    );
+    res.json(reminderRow(rows[0]));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.put("/reminder/:id", auth, async (req, res) => {
+  try {
+    const { title, description, date, time, priority, completed } = req.body;
+    const { rows } = await pool.query(
+      `UPDATE reminders SET
+        title = COALESCE($1, title),
+        description = COALESCE($2, description),
+        date = $3,
+        time = COALESCE($4, time),
+        priority = COALESCE($5, priority),
+        completed = COALESCE($6, completed)
+       WHERE id = $7 AND user_id = $8 RETURNING *`,
+      [
+        title,
+        description,
+        date || null,
+        time,
+        priority,
+        completed,
+        req.params.id,
+        req.userId,
+      ]
+    );
+    if (!rows[0]) return res.status(404).json({ message: "Not found" });
+    res.json(reminderRow(rows[0]));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.delete("/reminder/:id", auth, async (req, res) => {
+  try {
+    await pool.query(
+      "DELETE FROM reminders WHERE id = $1 AND user_id = $2",
+      [req.params.id, req.userId]
+    );
+    res.json({ message: "Deleted" });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// ── Timer modes ───────────────────────────────────────────────────────────────
+
+app.get("/timer", auth, async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      "SELECT * FROM timer_modes WHERE user_id = $1",
+      [req.userId]
+    );
+    res.json(
+      rows.map((r) => ({
+        name: r.name,
+        focusTime: r.focus_time,
+        shortBreak: r.short_break,
+        longBreak: r.long_break,
+      }))
+    );
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post("/timer", auth, async (req, res) => {
+  try {
+    const { name, focusTime, shortBreak, longBreak } = req.body;
+    const { rows: existing } = await pool.query(
+      "SELECT id FROM timer_modes WHERE user_id = $1 AND name = $2",
+      [req.userId, name]
+    );
+    if (existing.length > 0) {
+      await pool.query(
+        "UPDATE timer_modes SET focus_time = $1, short_break = $2, long_break = $3 WHERE user_id = $4 AND name = $5",
+        [focusTime, shortBreak, longBreak, req.userId, name]
+      );
+    } else {
+      await pool.query(
+        "INSERT INTO timer_modes (name, focus_time, short_break, long_break, user_id) VALUES ($1, $2, $3, $4, $5)",
+        [name, focusTime, shortBreak, longBreak, req.userId]
+      );
+    }
+    res.json({ message: "Timer mode saved" });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.get("/timer/session-count", auth, async (req, res) => {
+  try {
+    const today = new Date().toISOString().split("T")[0];
+    const { rows } = await pool.query(
+      "SELECT session_count FROM session_counts WHERE user_id = $1 AND date = $2",
+      [req.userId, today]
+    );
+    res.json({ data: { sessionCount: rows[0]?.session_count || 0 } });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post("/timer/session-count", auth, async (req, res) => {
+  try {
+    const { sessionCount, date } = req.body;
+    const d = date
+      ? new Date(date).toISOString().split("T")[0]
+      : new Date().toISOString().split("T")[0];
+    const { rows: existing } = await pool.query(
+      "SELECT id FROM session_counts WHERE user_id = $1 AND date = $2",
+      [req.userId, d]
+    );
+    if (existing.length > 0) {
+      await pool.query(
+        "UPDATE session_counts SET session_count = $1 WHERE user_id = $2 AND date = $3",
+        [sessionCount, req.userId, d]
+      );
+    } else {
+      await pool.query(
+        "INSERT INTO session_counts (session_count, date, user_id) VALUES ($1, $2, $3)",
+        [sessionCount, d, req.userId]
+      );
+    }
+    res.json({ message: "Session count updated" });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// ── Agent (stub) ──────────────────────────────────────────────────────────────
+
+app.post("/agent/chat", auth, (_req, res) => {
+  res.json({ content: "AI agent is not available in local test mode." });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () =>
+  console.log(`Zendoro test backend running on http://localhost:${PORT}`)
+);

--- a/test-backend/package.json
+++ b/test-backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "zendoro-test-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node seed.js && node index.js",
+    "seed": "node seed.js"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "pg": "^8.11.3"
+  }
+}

--- a/test-backend/seed.js
+++ b/test-backend/seed.js
@@ -1,0 +1,168 @@
+const { Pool } = require("pg");
+const bcrypt = require("bcryptjs");
+
+const pool = new Pool({
+  connectionString:
+    process.env.DATABASE_URL ||
+    "postgresql://postgres:postgres@localhost:5432/zendoro_test",
+});
+
+async function waitForDb(retries = 15, delayMs = 2000) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      await pool.query("SELECT 1");
+      console.log("Database ready.");
+      return;
+    } catch {
+      console.log(`Waiting for database... (${i + 1}/${retries})`);
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  throw new Error("Could not connect to database after retries.");
+}
+
+async function seed() {
+  await waitForDb();
+
+  // Create tables
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS users (
+      id SERIAL PRIMARY KEY,
+      name VARCHAR(255) NOT NULL,
+      email VARCHAR(255) UNIQUE NOT NULL,
+      password VARCHAR(255) NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS todos (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL,
+      description TEXT,
+      status VARCHAR(50) DEFAULT 'TODO',
+      due_date TIMESTAMP,
+      user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+    CREATE TABLE IF NOT EXISTS hobbies (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name VARCHAR(255) NOT NULL,
+      completions BOOLEAN[] DEFAULT '{false,false,false,false,false,false,false}',
+      user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS reminders (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL,
+      description TEXT,
+      date DATE,
+      time VARCHAR(10),
+      priority VARCHAR(10) DEFAULT 'low',
+      completed BOOLEAN DEFAULT false,
+      user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS timer_modes (
+      id SERIAL PRIMARY KEY,
+      name VARCHAR(50),
+      focus_time INTEGER,
+      short_break INTEGER,
+      long_break INTEGER,
+      user_id INTEGER REFERENCES users(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS session_counts (
+      id SERIAL PRIMARY KEY,
+      session_count INTEGER DEFAULT 0,
+      date DATE DEFAULT CURRENT_DATE,
+      user_id INTEGER REFERENCES users(id) ON DELETE CASCADE
+    );
+  `);
+
+  // Skip seeding if user already exists
+  const { rows: existing } = await pool.query(
+    "SELECT id FROM users WHERE email = $1",
+    ["test@zendoro.dev"]
+  );
+  if (existing.length > 0) {
+    console.log("Seed data already present. Skipping.");
+    await pool.end();
+    return;
+  }
+
+  const passwordHash = bcrypt.hashSync("password123", 10);
+  const {
+    rows: [user],
+  } = await pool.query(
+    "INSERT INTO users (name, email, password) VALUES ($1, $2, $3) RETURNING id",
+    ["Alice Demo", "test@zendoro.dev", passwordHash]
+  );
+  const uid = user.id;
+
+  const today = new Date().toISOString().split("T")[0];
+
+  // Todos — realistic mix across all statuses
+  await pool.query(`
+    INSERT INTO todos (title, description, status, due_date, user_id) VALUES
+    ('Set up project repository', 'Initialize git repo and CI/CD pipeline', 'Done', '2026-06-20', ${uid}),
+    ('Design wireframes', 'Create Figma mockups for all main screens', 'Done', '2026-06-22', ${uid}),
+    ('Implement auth flow', 'Login, signup, JWT tokens', 'Done', '2026-06-23', ${uid}),
+    ('Build todo CRUD', 'Create, read, update, delete todos via API', 'Done', '2026-06-24', ${uid}),
+    ('Write unit tests', 'Cover core utilities and store functions', 'Done', '2026-06-24', ${uid}),
+    ('Dashboard analytics', 'Build charts and KPI cards for the main dashboard', 'In Progress', '2026-06-28', ${uid}),
+    ('Mobile responsive layout', 'Make all pages work well on smaller screens', 'In Progress', '2026-06-30', ${uid}),
+    ('Dark mode toggle', 'Add theme switching with persisted preference', 'TODO', '2026-07-02', ${uid}),
+    ('Notification system', 'In-app notifications for upcoming reminders', 'TODO', '2026-07-05', ${uid}),
+    ('Export data to CSV', 'Allow users to export their todos and habits', 'TODO', '2026-07-10', ${uid}),
+    ('Build native mobile app', 'React Native version — deprioritized', 'Kill', NULL, ${uid})
+  `);
+
+  // Habits — 5 habits with varied weekly completion patterns
+  await pool.query(`
+    INSERT INTO hobbies (name, completions, user_id) VALUES
+    ('Morning workout', '{true,true,false,true,true,false,false}', ${uid}),
+    ('Read 30 min', '{true,true,true,true,false,true,false}', ${uid}),
+    ('Meditate', '{true,false,true,true,true,false,true}', ${uid}),
+    ('No social media before 10am', '{true,true,true,false,true,true,false}', ${uid}),
+    ('Drink 2L water', '{false,true,true,true,true,false,true}', ${uid})
+  `);
+
+  // Reminders — today, overdue, upcoming, and one completed
+  await pool.query(`
+    INSERT INTO reminders (title, description, date, time, priority, completed, user_id) VALUES
+    ('Team standup', 'Daily sync with the engineering team', '${today}', '10:00', 'high', false, ${uid}),
+    ('Review PR #12', 'Dashboard feature PR needs code review', '${today}', '14:00', 'medium', false, ${uid}),
+    ('Submit expense report', 'Q2 expenses are overdue — finance is waiting', '2026-06-20', '17:00', 'high', false, ${uid}),
+    ('Call dentist', 'Schedule appointment for next month', '2026-06-22', '09:00', 'low', false, ${uid}),
+    ('Project demo', 'Demo the new dashboard to the team', '2026-06-27', '15:00', 'high', false, ${uid}),
+    ('Monthly review', 'Personal OKR review session', '2026-06-30', '10:00', 'medium', false, ${uid}),
+    ('Doctor appointment', 'Annual checkup', '2026-07-05', '11:30', 'medium', false, ${uid}),
+    ('Setup dev environment', 'Completed task for reference', '2026-06-18', '09:00', 'low', true, ${uid})
+  `);
+
+  // Timer modes
+  await pool.query(`
+    INSERT INTO timer_modes (name, focus_time, short_break, long_break, user_id) VALUES
+    ('Standard', 25, 5, 15, ${uid}),
+    ('Extended', 45, 10, 20, ${uid}),
+    ('Long run', 90, 15, 30, ${uid})
+  `);
+
+  // Focus session count for today
+  await pool.query(
+    "INSERT INTO session_counts (session_count, date, user_id) VALUES ($1, $2, $3)",
+    [7, today, uid]
+  );
+
+  console.log(`Seeded database with test user: test@zendoro.dev / password123`);
+  await pool.end();
+}
+
+seed().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,5 +17,6 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+    dedupe: ["react", "react-dom"],
   },
 });


### PR DESCRIPTION
## Summary

- **Todo page** redesigned as a 4-column Kanban board (TODO / In Progress / Done / Kill) — drag a card between columns to update its status via the API
- **Dashboard Upcoming & Overdue** section converted to a time-bucket Kanban (Overdue / Today / Tomorrow / Upcoming) — dragging a todo card to a different column reschedules its due date; reminder cards are static
- **Local test stack** added (`docker-compose.yml` + `test-backend/`) — PostgreSQL + Express mock backend with a seeded demo account (`test@zendoro.dev` / `password123`), so the dashboard can be previewed without touching the production database
- **API base URL** is now configurable via `VITE_API_URL` env var (falls back to the production URL), allowing `.env.local` to point at the local stack
- Added `react`/`react-dom` dedupe in `vite.config.ts` to fix `@dnd-kit` hook compatibility with React 19



