### PR TITLE
feat: add skeleton loading states to dashboard, todo, and reminder pages

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-white/10", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -14,6 +14,7 @@ import { TodoStatusChart } from "@/componenets/Dashboard/TodoStatusChart";
 import { HabitProgressChart } from "@/componenets/Dashboard/HabitProgressChart";
 import { UpcomingAgenda } from "@/componenets/Dashboard/UpcomingAgenda";
 import { MiniReminderCalendar } from "@/componenets/Dashboard/MiniReminderCalendar";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/")({
   component: RouteComponent,
@@ -43,6 +44,61 @@ function Panel({
   );
 }
 
+function DashboardSkeleton() {
+  return (
+    <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
+      {/* Header */}
+      <header className="mb-6 md:mb-8 space-y-2">
+        <Skeleton className="h-8 w-40 md:h-10" />
+        <Skeleton className="h-4 w-64" />
+      </header>
+
+      {/* KPI cards */}
+      <section className="mb-6 grid grid-cols-2 gap-3 md:mb-8 md:gap-4 lg:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-white/10 bg-white/5 p-4 md:p-5 space-y-3"
+          >
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-8 w-8 rounded-lg" />
+            </div>
+            <Skeleton className="h-7 w-16" />
+            <Skeleton className="h-3 w-28" />
+          </div>
+        ))}
+      </section>
+
+      {/* Chart panels */}
+      <section className="mb-6 grid grid-cols-1 gap-4 md:mb-8 md:gap-6 lg:grid-cols-2">
+        {[...Array(2)].map((_, i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-white/10 bg-white/5 p-4 md:p-5 space-y-4"
+          >
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-40 w-full rounded-lg" />
+          </div>
+        ))}
+      </section>
+
+      {/* Bottom panels */}
+      <section className="grid grid-cols-1 gap-4 md:gap-6 lg:grid-cols-2">
+        {[...Array(2)].map((_, i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-white/10 bg-white/5 p-4 md:p-5 space-y-4"
+          >
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-48 w-full rounded-lg" />
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}
+
 const greeting = (): string => {
   const hour = new Date().getHours();
   if (hour < 12) return "Good morning";
@@ -53,14 +109,16 @@ const greeting = (): string => {
 function RouteComponent() {
   useDocumentTitle("Dashboard");
 
-  const { todos, fetchTodos } = useTodoStore();
+  const { todos, fetchTodos, isLoading: todosLoading, hasInitialized: todosReady } = useTodoStore();
   const {
     reminders,
     fetchReminders,
     getTodayReminders,
     getOverdueReminders,
+    isLoading: remindersLoading,
+    hasInitialized: remindersReady,
   } = useReminderStore();
-  const { habits, fetchHabits } = useHabitStore();
+  const { habits, fetchHabits, isLoading: habitsLoading, hasInitialized: habitsReady } = useHabitStore();
   const { currentFocusSessionCount, fetchFocusSessionCount } =
     useModeStore() as {
       currentFocusSessionCount: number;
@@ -74,11 +132,18 @@ function RouteComponent() {
     fetchFocusSessionCount();
   }, [fetchTodos, fetchReminders, fetchHabits, fetchFocusSessionCount]);
 
+  const isLoading =
+    (!todosReady && todosLoading) ||
+    (!remindersReady && remindersLoading) ||
+    (!habitsReady && habitsLoading);
+
   const todoStats = useMemo(() => getTodoStats(todos), [todos]);
   const habitStats = useMemo(() => getHabitStats(habits), [habits]);
 
   const todayReminders = getTodayReminders();
   const overdueReminders = getOverdueReminders();
+
+  if (isLoading) return <DashboardSkeleton />;
 
   return (
     <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">

--- a/src/routes/reminder.tsx
+++ b/src/routes/reminder.tsx
@@ -10,6 +10,7 @@ import { ReminderList } from "@/componenets/Reminder/ReminderList";
 import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { isAuthenticated } from "@/lib/authVerification";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/reminder")({
   component: RouteComponent,
@@ -22,11 +23,52 @@ export const Route = createFileRoute("/reminder")({
   },
 });
 
+function ReminderSkeleton() {
+  return (
+    <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
+      {/* Header */}
+      <header className="mb-6 md:mb-8 space-y-3">
+        <Skeleton className="h-8 w-48 md:h-10" />
+        <Skeleton className="h-4 w-72" />
+        {/* Badge row */}
+        <div className="flex flex-wrap gap-2 md:gap-4">
+          {[...Array(3)].map((_, i) => (
+            <Skeleton key={i} className="h-7 w-24 rounded-full" />
+          ))}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 md:gap-6">
+        {/* Calendar skeleton */}
+        <div className="lg:col-span-2 rounded-lg p-3 md:p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-6 w-24 md:h-7" />
+            <Skeleton className="h-9 w-32 rounded-lg" />
+          </div>
+          <Skeleton className="h-72 w-full rounded-xl" />
+        </div>
+
+        {/* Reminder list skeleton */}
+        <div className="lg:col-span-1 rounded-lg p-3 md:p-6 space-y-4">
+          <Skeleton className="h-5 w-48" />
+          <div className="space-y-3">
+            {[...Array(4)].map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function RouteComponent() {
   useDocumentTitle("Reminders");
 
   const {
     reminders,
+    isLoading,
+    hasInitialized,
     selectedDate,
     showForm,
     editingReminder,
@@ -52,6 +94,8 @@ function RouteComponent() {
   React.useEffect(() => {
     fetchReminders();
   }, [fetchReminders]);
+
+  if (!hasInitialized && isLoading) return <ReminderSkeleton />;
 
   const handleAddReminder = (reminder: Omit<Reminder, "id" | "userId">) => {
     void addReminder(reminder);

--- a/src/routes/todo.tsx
+++ b/src/routes/todo.tsx
@@ -38,6 +38,7 @@ import TodoComponent from "@/componenets/TodoList/Todo";
 import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { isAuthenticated } from "@/lib/authVerification";
 import { containsDangerousInput } from "@/lib/inputSanitization";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/todo")({
   component: RouteComponent,
@@ -156,6 +157,49 @@ function DroppableColumn({
   );
 }
 
+function TodoSkeleton() {
+  return (
+    <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
+      {/* Form skeleton */}
+      <div className="max-w-2xl mx-auto mb-6 md:mb-8 space-y-3 px-2 md:px-0">
+        <div className="space-y-1">
+          <Skeleton className="h-3 w-10" />
+          <Skeleton className="h-8 md:h-9 w-full" />
+        </div>
+        <div className="space-y-1">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-8 md:h-9 w-full" />
+        </div>
+        <div className="flex flex-col sm:flex-row gap-2 md:gap-3">
+          <Skeleton className="h-8 md:h-9 flex-1" />
+          <Skeleton className="h-8 md:h-9 flex-1" />
+          <Skeleton className="h-8 md:h-9 w-full sm:w-10" />
+        </div>
+      </div>
+
+      {/* Kanban columns skeleton */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {COLUMNS.map((col) => (
+          <div
+            key={col.status}
+            className={`rounded-xl border ${col.borderColor} bg-white/3 overflow-hidden`}
+          >
+            <div className={`flex items-center justify-between px-3 py-2.5 ${col.headerBg}`}>
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-5 w-5 rounded-full" />
+            </div>
+            <div className="flex flex-col gap-2 p-2 min-h-[80px]">
+              {[...Array(2)].map((_, i) => (
+                <Skeleton key={i} className="h-16 w-full rounded-md" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function RouteComponent() {
   useDocumentTitle("Todo List");
 
@@ -163,7 +207,7 @@ function RouteComponent() {
   const [date, setDate] = useState<Date | undefined>(undefined);
   const [status, setStatus] = useState<string>("");
   const [activeId, setActiveId] = useState<string | null>(null);
-  const { addTodo, updateTodo, todos, fetchTodos } = useTodoStore();
+  const { addTodo, updateTodo, todos, fetchTodos, isLoading, hasInitialized } = useTodoStore();
   const fetchReminders = useReminderStore((s) => s.fetchReminders);
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
 
@@ -171,6 +215,8 @@ function RouteComponent() {
     fetchTodos();
     fetchReminders();
   }, [fetchTodos, fetchReminders]);
+
+  if (!hasInitialized && isLoading) return <TodoSkeleton />;
 
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),

--- a/src/zustand/reminderStore.ts
+++ b/src/zustand/reminderStore.ts
@@ -47,6 +47,8 @@ const parseDateFromApi = (value: string | null): Date => {
 
 interface ReminderStore {
   reminders: Reminder[];
+  isLoading: boolean;
+  hasInitialized: boolean;
   selectedDate: Date;
   showForm: boolean;
   editingReminder: Reminder | null;
@@ -78,12 +80,15 @@ interface ReminderStore {
 
 export const useReminderStore = create<ReminderStore>()((set, get) => ({
   reminders: [],
+  isLoading: false,
+  hasInitialized: false,
   selectedDate: new Date(),
   showForm: false,
   editingReminder: null,
   deletingReminder: null,
 
   fetchReminders: async () => {
+    set({ isLoading: true });
     try {
       const authToken = getAuthToken();
       const headers: HeadersInit = {
@@ -107,10 +112,10 @@ export const useReminderStore = create<ReminderStore>()((set, get) => ({
         todoId: r.todoId ?? null,
         userId: r.userId,
       }));
-      set({ reminders });
+      set({ reminders, isLoading: false, hasInitialized: true });
     } catch (e) {
       console.error("Error fetching reminders", e);
-      set({ reminders: [] });
+      set({ reminders: [], isLoading: false, hasInitialized: true });
     }
   },
 

--- a/src/zustand/todoStore.ts
+++ b/src/zustand/todoStore.ts
@@ -14,6 +14,8 @@ export type Todo = {
 
 type TodoStore = {
   todos: Todo[];
+  isLoading: boolean;
+  hasInitialized: boolean;
   fetchTodos: () => Promise<void>;
   addTodo: (todo: Omit<Todo, "id" | "userId">) => Promise<void>;
   updateTodo: (
@@ -131,9 +133,12 @@ const deleteTodo = async (id: number) => {
 };
 export const useTodoStore = create<TodoStore>()((set) => ({
   todos: [],
+  isLoading: false,
+  hasInitialized: false,
   fetchTodos: async () => {
+    set({ isLoading: true });
     const todos = await getTodos();
-    set({ todos });
+    set({ todos, isLoading: false, hasInitialized: true });
   },
   addTodo: async (todo) => {
     try {
@@ -178,5 +183,5 @@ export const useTodoStore = create<TodoStore>()((set) => ({
     }
   },
 
-  clearTodos: () => set({ todos: [] }),
+  clearTodos: () => set({ todos: [], hasInitialized: false }),
 }));


### PR DESCRIPTION
## Summary

Adds proper skeleton loading states across all pages that were missing them, using a new shared \Skeleton\ UI component.

## Changes

### New
- \src/components/ui/skeleton.tsx\ — shared \Skeleton\ component (\nimate-pulse\ + \g-white/10\), consistent with the project's dark theme

### Stores
- \	odoStore\ — added \isLoading\ and \hasInitialized\ flags, set during \etchTodos\
- \eminderStore\ — same, set during \etchReminders\

### Pages
| Page | Skeleton component | Covers |
|---|---|---|
| Dashboard (\/\) | \DashboardSkeleton\ | Header, 4 KPI cards, 2 chart panels, 2 bottom panels |
| Todo (\/todo\) | \TodoSkeleton\ | Add-task form, all 4 kanban columns with accent colors |
| Reminder (\/reminder\) | \ReminderSkeleton\ | Badge row, calendar panel, reminder list |

### Not changed
- **Habit tracker** — already had a skeleton loading state
- **Focus page** — loading handled internally by \ModeSelection\ and \StatusTopLine\ sub-components