### PR TITLE
feat: dashboard date range filter (frontend + backend)

### DIFF
--- a/src/componenets/Dashboard/DateRangeFilter.tsx
+++ b/src/componenets/Dashboard/DateRangeFilter.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { format } from "date-fns";
+import { CalendarRange } from "lucide-react";
+import type { DateRange as RdpRange } from "react-day-picker";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { DashboardPreset, DateRange } from "@/zustand/dashboardStore";
+
+const PRESETS: { value: Exclude<DashboardPreset, "custom">; label: string }[] = [
+  { value: "all", label: "All time" },
+  { value: "today", label: "Today" },
+  { value: "7d", label: "7 days" },
+  { value: "month", label: "This month" },
+];
+
+interface DateRangeFilterProps {
+  preset: DashboardPreset;
+  range: DateRange;
+  onChange: (preset: DashboardPreset, custom?: DateRange) => void;
+}
+
+export function DateRangeFilter({
+  preset,
+  range,
+  onChange,
+}: DateRangeFilterProps) {
+  const [open, setOpen] = useState(false);
+
+  const customLabel =
+    preset === "custom" && range.from && range.to
+      ? `${format(range.from, "MMM d")} – ${format(range.to, "MMM d")}`
+      : "Custom";
+
+  const handleRangeSelect = (selected: RdpRange | undefined) => {
+    if (selected?.from && selected?.to) {
+      onChange("custom", { from: selected.from, to: selected.to });
+      setOpen(false);
+    }
+  };
+
+  const pillClass = (active: boolean) =>
+    cn(
+      "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+      active
+        ? "bg-white/15 text-white"
+        : "bg-white/5 text-white/60 hover:bg-white/10 hover:text-white",
+    );
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {PRESETS.map((p) => (
+        <button
+          key={p.value}
+          type="button"
+          onClick={() => onChange(p.value)}
+          className={pillClass(preset === p.value)}
+        >
+          {p.label}
+        </button>
+      ))}
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            className={cn(
+              "h-auto rounded-full px-3 py-1 text-xs font-medium",
+              preset === "custom"
+                ? "bg-white/15 text-white hover:bg-white/20"
+                : "bg-white/5 text-white/60 hover:bg-white/10 hover:text-white",
+            )}
+          >
+            <CalendarRange className="mr-1.5 h-3.5 w-3.5" />
+            {customLabel}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto overflow-hidden p-0" align="end">
+          <Calendar
+            mode="range"
+            numberOfMonths={2}
+            defaultMonth={range.from ?? undefined}
+            selected={
+              preset === "custom" && range.from && range.to
+                ? { from: range.from, to: range.to }
+                : undefined
+            }
+            onSelect={handleRangeSelect}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,20 +1,28 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useEffect, useMemo } from "react";
-import { format } from "date-fns";
+import { format, startOfDay } from "date-fns";
 import { Timer, CheckSquare, Bell, Target } from "lucide-react";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { isAuthenticated } from "@/lib/authVerification";
-import { useTodoStore } from "@/zustand/todoStore";
-import { useReminderStore } from "@/zustand/reminderStore";
 import { useHabitStore } from "@/zustand/habbitStore";
-import { useModeStore } from "@/zustand/modeStore";
+import { useDashboardStore } from "@/zustand/dashboardStore";
+import type { DashboardPreset } from "@/zustand/dashboardStore";
 import { getTodoStats, getHabitStats } from "@/lib/dashboardStats";
 import { StatCard } from "@/componenets/Dashboard/StatCard";
 import { TodoStatusChart } from "@/componenets/Dashboard/TodoStatusChart";
 import { HabitProgressChart } from "@/componenets/Dashboard/HabitProgressChart";
 import { UpcomingAgenda } from "@/componenets/Dashboard/UpcomingAgenda";
 import { MiniReminderCalendar } from "@/componenets/Dashboard/MiniReminderCalendar";
+import { DateRangeFilter } from "@/componenets/Dashboard/DateRangeFilter";
 import { Skeleton } from "@/components/ui/skeleton";
+
+const RANGE_SUB_LABEL: Record<DashboardPreset, string> = {
+  all: "all time",
+  today: "today",
+  "7d": "last 7 days",
+  month: "this month",
+  custom: "in range",
+};
 
 export const Route = createFileRoute("/")({
   component: RouteComponent,
@@ -109,52 +117,65 @@ const greeting = (): string => {
 function RouteComponent() {
   useDocumentTitle("Dashboard");
 
-  const { todos, fetchTodos, isLoading: todosLoading, hasInitialized: todosReady } = useTodoStore();
   const {
+    todos,
     reminders,
-    fetchReminders,
-    getTodayReminders,
-    getOverdueReminders,
-    isLoading: remindersLoading,
-    hasInitialized: remindersReady,
-  } = useReminderStore();
-  const { habits, fetchHabits, isLoading: habitsLoading, hasInitialized: habitsReady } = useHabitStore();
-  const { currentFocusSessionCount, fetchFocusSessionCount } =
-    useModeStore() as {
-      currentFocusSessionCount: number;
-      fetchFocusSessionCount: () => void;
-    };
+    focusSessionCount,
+    preset,
+    range,
+    setRange,
+    fetchDashboard,
+    isLoading: dashLoading,
+    hasInitialized: dashReady,
+  } = useDashboardStore();
+  const {
+    habits,
+    fetchHabits,
+    isLoading: habitsLoading,
+    hasInitialized: habitsReady,
+  } = useHabitStore();
 
   useEffect(() => {
-    fetchTodos();
-    fetchReminders();
+    fetchDashboard();
     fetchHabits();
-    fetchFocusSessionCount();
-  }, [fetchTodos, fetchReminders, fetchHabits, fetchFocusSessionCount]);
+  }, [fetchDashboard, fetchHabits]);
 
-  const isLoading =
-    (!todosReady && todosLoading) ||
-    (!remindersReady && remindersLoading) ||
-    (!habitsReady && habitsLoading);
+  const isInitialLoading =
+    (!dashReady && dashLoading) || (!habitsReady && habitsLoading);
 
   const todoStats = useMemo(() => getTodoStats(todos), [todos]);
   const habitStats = useMemo(() => getHabitStats(habits), [habits]);
 
-  const todayReminders = getTodayReminders();
-  const overdueReminders = getOverdueReminders();
+  const { reminderCount, overdueReminders, completedReminders } = useMemo(() => {
+    const today = startOfDay(new Date());
+    let overdue = 0;
+    let completed = 0;
+    for (const r of reminders) {
+      if (r.completed) completed += 1;
+      else if (r.date < today) overdue += 1;
+    }
+    return {
+      reminderCount: reminders.length,
+      overdueReminders: overdue,
+      completedReminders: completed,
+    };
+  }, [reminders]);
 
-  if (isLoading) return <DashboardSkeleton />;
+  if (isInitialLoading) return <DashboardSkeleton />;
 
   return (
     <div className="max-w-7xl mx-auto p-2 md:p-4 overflow-x-hidden">
-      <header className="mb-6 md:mb-8">
-        <h1 className="mb-1 text-2xl font-bold text-white md:text-4xl">
-          Dashboard
-        </h1>
-        <p className="text-sm text-white/70 md:text-base">
-          {greeting()}, here's your overview for{" "}
-          {format(new Date(), "EEEE, MMMM d")}
-        </p>
+      <header className="mb-6 md:mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h1 className="mb-1 text-2xl font-bold text-white md:text-4xl">
+            Dashboard
+          </h1>
+          <p className="text-sm text-white/70 md:text-base">
+            {greeting()}, here's your overview for{" "}
+            {format(new Date(), "EEEE, MMMM d")}
+          </p>
+        </div>
+        <DateRangeFilter preset={preset} range={range} onChange={setRange} />
       </header>
 
       {/* KPI summary */}
@@ -162,8 +183,8 @@ function RouteComponent() {
         <StatCard
           icon={Timer}
           label="Focus Sessions"
-          value={currentFocusSessionCount}
-          sub="completed today"
+          value={focusSessionCount}
+          sub={`completed ${RANGE_SUB_LABEL[preset]}`}
           accent="text-sky-400"
         />
         <StatCard
@@ -177,10 +198,12 @@ function RouteComponent() {
         />
         <StatCard
           icon={Bell}
-          label="Reminders Today"
-          value={todayReminders}
+          label="Reminders"
+          value={reminderCount}
           sub={
-            overdueReminders > 0 ? `${overdueReminders} overdue` : "none overdue"
+            overdueReminders > 0
+              ? `${overdueReminders} overdue`
+              : `${completedReminders} completed`
           }
           accent="text-amber-400"
         />

--- a/src/zustand/dashboardStore.ts
+++ b/src/zustand/dashboardStore.ts
@@ -1,0 +1,163 @@
+import { create } from "zustand";
+import {
+  startOfDay,
+  endOfDay,
+  subDays,
+  startOfMonth,
+  endOfMonth,
+} from "date-fns";
+import { API_BASE_URL } from "@/constants/data";
+import { getAuthToken } from "@/lib/authHelpers";
+import type { Todo } from "./todoStore";
+import type { Reminder } from "./reminderStore";
+
+// The dashboard keeps its own copy of date-scoped data so the date filter never
+// pollutes the shared todo/reminder stores used by the Todo and Reminder pages.
+
+export type DashboardPreset = "all" | "today" | "7d" | "month" | "custom";
+
+export interface DateRange {
+  from: Date | null; // null = unbounded
+  to: Date | null;
+}
+
+type ApiTodo = Omit<Todo, "dueDate"> & { dueDate: string | null };
+
+type ApiReminder = {
+  id: number;
+  title: string;
+  description?: string | null;
+  date: string | null;
+  time: string;
+  priority: "low" | "medium" | "high";
+  completed: boolean;
+  todoId?: number | null;
+  userId?: number;
+};
+
+const toYmd = (d: Date): string => {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+};
+
+const parseReminderDate = (value: string | null): Date => {
+  if (!value) return new Date();
+  if (value.includes("T")) return new Date(value);
+  const [y, m, d] = value.split("-").map((v) => Number(v));
+  if (Number.isFinite(y) && Number.isFinite(m) && Number.isFinite(d)) {
+    return new Date(y, m - 1, d);
+  }
+  return new Date(value);
+};
+
+export const rangeForPreset = (preset: DashboardPreset): DateRange => {
+  const now = new Date();
+  switch (preset) {
+    case "today":
+      return { from: startOfDay(now), to: endOfDay(now) };
+    case "7d":
+      return { from: startOfDay(subDays(now, 6)), to: endOfDay(now) };
+    case "month":
+      return { from: startOfMonth(now), to: endOfMonth(now) };
+    case "all":
+    case "custom":
+    default:
+      return { from: null, to: null };
+  }
+};
+
+const buildRangeQuery = (range: DateRange): string => {
+  const params = new URLSearchParams();
+  if (range.from) params.set("from", toYmd(range.from));
+  if (range.to) params.set("to", toYmd(range.to));
+  const s = params.toString();
+  return s ? `?${s}` : "";
+};
+
+interface DashboardStore {
+  preset: DashboardPreset;
+  range: DateRange;
+  todos: Todo[];
+  reminders: Reminder[];
+  focusSessionCount: number;
+  isLoading: boolean;
+  hasInitialized: boolean;
+  setRange: (preset: DashboardPreset, custom?: DateRange) => void;
+  fetchDashboard: () => Promise<void>;
+}
+
+export const useDashboardStore = create<DashboardStore>()((set, get) => ({
+  preset: "all",
+  range: rangeForPreset("all"),
+  todos: [],
+  reminders: [],
+  focusSessionCount: 0,
+  isLoading: false,
+  hasInitialized: false,
+
+  setRange: (preset, custom) => {
+    const range =
+      preset === "custom" && custom ? custom : rangeForPreset(preset);
+    set({ preset, range });
+    void get().fetchDashboard();
+  },
+
+  fetchDashboard: async () => {
+    set({ isLoading: true });
+    const { preset, range } = get();
+    const q = buildRangeQuery(range);
+    // Todos/reminders with no range return everything (incl. items without a
+    // date). The session-count endpoint, however, defaults to *today* when
+    // unbounded — so for "all time" we request an open-ended range to get the
+    // all-time total instead.
+    const sessionQ = preset === "all" ? "?from=1970-01-01" : q;
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${getAuthToken()}`,
+    };
+    try {
+      const [todosRes, remindersRes, sessionRes] = await Promise.all([
+        fetch(`${API_BASE_URL}/todo${q}`, { headers }),
+        fetch(`${API_BASE_URL}/reminder${q}`, { headers }),
+        fetch(`${API_BASE_URL}/timer/session-count${sessionQ}`, { headers }),
+      ]);
+
+      const todosData: ApiTodo[] = todosRes.ok ? await todosRes.json() : [];
+      const remindersData: ApiReminder[] = remindersRes.ok
+        ? await remindersRes.json()
+        : [];
+      const sessionData = sessionRes.ok
+        ? await sessionRes.json()
+        : { data: { sessionCount: 0 } };
+
+      const todos: Todo[] = todosData.map((t) => ({
+        ...t,
+        dueDate: t.dueDate ? new Date(t.dueDate) : null,
+      }));
+      const reminders: Reminder[] = remindersData.map((r) => ({
+        id: Number(r.id),
+        title: r.title,
+        description: r.description ?? undefined,
+        date: parseReminderDate(r.date),
+        time: r.time,
+        priority: r.priority,
+        completed: r.completed,
+        todoId: r.todoId ?? null,
+        userId: r.userId,
+      }));
+
+      set({
+        todos,
+        reminders,
+        focusSessionCount: sessionData?.data?.sessionCount ?? 0,
+        isLoading: false,
+        hasInitialized: true,
+      });
+    } catch (e) {
+      console.error("Error fetching dashboard data", e);
+      set({ isLoading: false, hasInitialized: true });
+    }
+  },
+}));

--- a/test-backend/index.js
+++ b/test-backend/index.js
@@ -146,9 +146,24 @@ app.post("/auth/signup", async (req, res) => {
 
 app.get("/todo", auth, async (req, res) => {
   try {
+    // Optional date-range filter on due_date (?from=YYYY-MM-DD&to=YYYY-MM-DD).
+    // `to` is treated as inclusive of the whole day.
+    const { from, to } = req.query;
+    const clauses = ["user_id = $1"];
+    const params = [req.userId];
+    if (from) {
+      params.push(from);
+      clauses.push(`due_date >= $${params.length}::date`);
+    }
+    if (to) {
+      params.push(to);
+      clauses.push(`due_date < ($${params.length}::date + interval '1 day')`);
+    }
     const { rows } = await pool.query(
-      "SELECT * FROM todos WHERE user_id = $1 ORDER BY created_at DESC",
-      [req.userId]
+      `SELECT * FROM todos WHERE ${clauses.join(
+        " AND "
+      )} ORDER BY created_at DESC`,
+      params
     );
     res.json(rows.map(todoRow));
   } catch (err) {
@@ -272,9 +287,23 @@ app.delete("/hobby/:id", auth, async (req, res) => {
 
 app.get("/reminder", auth, async (req, res) => {
   try {
+    // Optional date-range filter on date (?from=YYYY-MM-DD&to=YYYY-MM-DD), inclusive.
+    const { from, to } = req.query;
+    const clauses = ["user_id = $1"];
+    const params = [req.userId];
+    if (from) {
+      params.push(from);
+      clauses.push(`date >= $${params.length}::date`);
+    }
+    if (to) {
+      params.push(to);
+      clauses.push(`date <= $${params.length}::date`);
+    }
     const { rows } = await pool.query(
-      "SELECT * FROM reminders WHERE user_id = $1 ORDER BY created_at DESC",
-      [req.userId]
+      `SELECT * FROM reminders WHERE ${clauses.join(
+        " AND "
+      )} ORDER BY created_at DESC`,
+      params
     );
     res.json(rows.map(reminderRow));
   } catch (err) {
@@ -401,6 +430,28 @@ app.post("/timer", auth, async (req, res) => {
 
 app.get("/timer/session-count", auth, async (req, res) => {
   try {
+    // With a date range (?from=YYYY-MM-DD&to=YYYY-MM-DD), sum sessions across
+    // the range; without it, fall back to today's count.
+    const { from, to } = req.query;
+    if (from || to) {
+      const clauses = ["user_id = $1"];
+      const params = [req.userId];
+      if (from) {
+        params.push(from);
+        clauses.push(`date >= $${params.length}::date`);
+      }
+      if (to) {
+        params.push(to);
+        clauses.push(`date <= $${params.length}::date`);
+      }
+      const { rows } = await pool.query(
+        `SELECT COALESCE(SUM(session_count), 0) AS total FROM session_counts WHERE ${clauses.join(
+          " AND "
+        )}`,
+        params
+      );
+      return res.json({ data: { sessionCount: Number(rows[0].total) } });
+    }
     const today = new Date().toISOString().split("T")[0];
     const { rows } = await pool.query(
       "SELECT session_count FROM session_counts WHERE user_id = $1 AND date = $2",


### PR DESCRIPTION
## Summary

Adds a **date-range filter to the dashboard** that scopes the KPI cards, Task Status chart, Reminders calendar, and Upcoming agenda to a selected period. Filtering is done **server-side** per the agreed approach.

Presets: **All time / Today / 7 days / This month** plus a **custom range** picker (two-month calendar).

## Backend (`test-backend/index.js`)

Added optional, backward-compatible `?from=YYYY-MM-DD&to=YYYY-MM-DD` query params to:

- `GET /todo` — filters by `due_date` (`to` inclusive of the whole day)
- `GET /reminder` — filters by `date` (inclusive)
- `GET /timer/session-count` — sums `session_count` across the range; with no params it keeps the legacy "today only" behavior the Focus page depends on

No params = existing behavior, so nothing else breaks.

## Frontend

- **`src/zustand/dashboardStore.ts`** (new) — a decoupled store holding range-scoped `todos`, `reminders`, and `focusSessionCount` plus the active `preset`/`range`. Key design choice: the dashboard no longer reads the shared todo/reminder stores, so its filter **can't corrupt the Todo/Reminder pages**.
- **`src/componenets/Dashboard/DateRangeFilter.tsx`** (new) — preset pills + custom range popover.
- **`src/routes/index.tsx`** — wires the filter into the header; cards/charts/agenda re-scope to the range and sub-labels adapt ("completed this month", etc.).

Habits are intentionally left unfiltered — they only store a Mon–Sun `completions[7]` for the current week, so there's no date dimension a range could apply to.

## Verification

- **API**: login + curl confirmed filtering (todos for July → 3 results, session-count sums over a range, no-param fallback returns today).
- **UI** (local docker backend): every preset re-scopes correctly — e.g. *This month* → 5/6 tasks, 8 reminders, 7 sessions; *7 days* → 3/3 tasks, 3 reminders; *Today* → 0/0, 0 reminders. Custom range popover opens with a working two-month calendar.
- Fixed an edge case: under **All time**, the focus card now requests an open-ended range so it shows the all-time session total instead of today's (the unbounded endpoint defaults to today).
- `tsc -b` and `eslint` pass clean.

## Notes

- The remote production backend won't honor the new params until deployed with this `index.js`; the filter degrades gracefully (returns unfiltered data) until then.
- Separately noticed a **pre-existing** conditional-hook crash in `src/routes/todo.tsx` (loading-skeleton early return before `useSensors`) — out of scope here, tracked separately.

