### PR TITLE
feat: add Goals (dedicated page + dashboard hero)

### DIFF
--- a/src/componenets/Goals/GoalFormDialog.tsx
+++ b/src/componenets/Goals/GoalFormDialog.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useMemo, useState } from "react";
+import { format } from "date-fns";
+import { CalendarIcon, CheckSquare, Repeat, Bell } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { useTodoStore } from "@/zustand/todoStore";
+import { useHabitStore } from "@/zustand/habbitStore";
+import { useReminderStore } from "@/zustand/reminderStore";
+import { useGoalStore, type Goal, type GoalInput } from "@/zustand/goalStore";
+
+interface GoalFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  goal?: Goal | null; // present → edit mode
+}
+
+// A scrollable list of selectable items used for linking todos/habits/reminders.
+function LinkSection<T>({
+  icon: Icon,
+  title,
+  items,
+  getId,
+  getLabel,
+  selected,
+  toggle,
+}: {
+  icon: typeof CheckSquare;
+  title: string;
+  items: T[];
+  getId: (item: T) => string;
+  getLabel: (item: T) => string;
+  selected: Set<string>;
+  toggle: (id: string) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" />
+        {title}
+        <span className="text-muted-foreground/60">({items.length})</span>
+      </div>
+      {items.length === 0 ? (
+        <p className="px-1 py-2 text-xs text-muted-foreground/60">
+          Nothing to link
+        </p>
+      ) : (
+        <ScrollArea className="h-28 rounded-lg border bg-muted/30 p-1">
+          {items.map((item) => {
+            const id = getId(item);
+            return (
+              <label
+                key={id}
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent"
+              >
+                <Checkbox
+                  checked={selected.has(id)}
+                  onCheckedChange={() => toggle(id)}
+                />
+                <span className="truncate">{getLabel(item)}</span>
+              </label>
+            );
+          })}
+        </ScrollArea>
+      )}
+    </div>
+  );
+}
+
+export function GoalFormDialog({
+  open,
+  onOpenChange,
+  goal,
+}: GoalFormDialogProps) {
+  const { addGoal, updateGoal } = useGoalStore();
+  const todos = useTodoStore((s) => s.todos);
+  const habits = useHabitStore((s) => s.habits);
+  const reminders = useReminderStore((s) => s.reminders);
+
+  const isEdit = Boolean(goal);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [targetDate, setTargetDate] = useState<Date | undefined>(undefined);
+  const [todoIds, setTodoIds] = useState<Set<string>>(new Set());
+  const [habitIds, setHabitIds] = useState<Set<string>>(new Set());
+  const [reminderIds, setReminderIds] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+
+  // Seed the form whenever the dialog opens (or the target goal changes).
+  useEffect(() => {
+    if (!open) return;
+    setTitle(goal?.title ?? "");
+    setDescription(goal?.description ?? "");
+    setTargetDate(goal?.targetDate ?? undefined);
+    setTodoIds(new Set((goal?.todoIds ?? []).map(String)));
+    setHabitIds(new Set((goal?.habitIds ?? []).map(String)));
+    setReminderIds(new Set((goal?.reminderIds ?? []).map(String)));
+  }, [open, goal]);
+
+  const toggle =
+    (setter: React.Dispatch<React.SetStateAction<Set<string>>>) =>
+    (id: string) =>
+      setter((prev) => {
+        const next = new Set(prev);
+        next.has(id) ? next.delete(id) : next.add(id);
+        return next;
+      });
+
+  const canSave = title.trim().length > 0 && !saving;
+
+  const handleSubmit = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    // Todo/reminder ids are numeric; habit ids may be UUID strings (mock) or
+    // numbers (prod) — pass habit ids through as their original string form.
+    const payload: GoalInput = {
+      title: title.trim(),
+      description: description.trim() || null,
+      targetDate: targetDate ?? null,
+      todoIds: [...todoIds].map(Number),
+      habitIds: [...habitIds],
+      reminderIds: [...reminderIds].map(Number),
+    };
+    try {
+      if (isEdit && goal) {
+        await updateGoal(goal.id, payload);
+      } else {
+        await addGoal(payload);
+      }
+      onOpenChange(false);
+    } catch {
+      // store logs the error; keep the dialog open so the user can retry
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const linkedCount = useMemo(
+    () => todoIds.size + habitIds.size + reminderIds.size,
+    [todoIds, habitIds, reminderIds],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Edit goal" : "New goal"}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="goal-title">Title</Label>
+            <Input
+              id="goal-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Ship v1"
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="goal-desc">Description</Label>
+            <Textarea
+              id="goal-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does success look like?"
+              rows={2}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Target date</Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="w-full justify-start font-normal"
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {targetDate ? format(targetDate, "PPP") : "No deadline"}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={targetDate}
+                  onSelect={setTargetDate}
+                />
+                {targetDate && (
+                  <div className="border-t p-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="w-full"
+                      onClick={() => setTargetDate(undefined)}
+                    >
+                      Clear date
+                    </Button>
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          <div className="space-y-3 rounded-xl border bg-muted/30 p-3">
+            <p className="text-xs font-medium">
+              Link items{" "}
+              <span className="text-muted-foreground">
+                {linkedCount > 0 ? `· ${linkedCount} selected` : ""}
+              </span>
+            </p>
+            <LinkSection
+              icon={CheckSquare}
+              title="Tasks"
+              items={todos}
+              getId={(t) => String(t.id)}
+              getLabel={(t) => t.title}
+              selected={todoIds}
+              toggle={toggle(setTodoIds)}
+            />
+            <LinkSection
+              icon={Repeat}
+              title="Habits"
+              items={habits}
+              getId={(h) => String(h.id)}
+              getLabel={(h) => h.name}
+              selected={habitIds}
+              toggle={toggle(setHabitIds)}
+            />
+            <LinkSection
+              icon={Bell}
+              title="Reminders"
+              items={reminders}
+              getId={(r) => String(r.id)}
+              getLabel={(r) => r.title}
+              selected={reminderIds}
+              toggle={toggle(setReminderIds)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!canSave}>
+            {saving ? "Saving…" : isEdit ? "Save changes" : "Create goal"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/componenets/Goals/GoalHero.tsx
+++ b/src/componenets/Goals/GoalHero.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { format } from "date-fns";
+import { ArrowRight, CalendarDays, Trophy } from "lucide-react";
+import { GoalRing } from "./GoalRing";
+import { progressForGoal } from "@/lib/goalProgress";
+import type { Goal } from "@/zustand/goalStore";
+import type { Todo } from "@/zustand/todoStore";
+import type { Habit } from "@/zustand/habbitStore";
+import type { Reminder } from "@/zustand/reminderStore";
+
+interface GoalHeroProps {
+  goals: Goal[];
+  todos: Todo[];
+  habits: Habit[];
+  reminders: Reminder[];
+}
+
+// Pick the goal to spotlight: prefer active goals with the nearest target
+// date; fall back to any active goal, then to whatever exists.
+function pickSpotlight(goals: Goal[]): Goal | null {
+  if (goals.length === 0) return null;
+  const active = goals.filter((g) => g.status === "active");
+  const pool = active.length ? active : goals;
+  return [...pool].sort((a, b) => {
+    const at = a.targetDate ? a.targetDate.getTime() : Infinity;
+    const bt = b.targetDate ? b.targetDate.getTime() : Infinity;
+    return at - bt;
+  })[0];
+}
+
+export function GoalHero({ goals, todos, habits, reminders }: GoalHeroProps) {
+  const goal = useMemo(() => pickSpotlight(goals), [goals]);
+  const progress = useMemo(
+    () => (goal ? progressForGoal(goal, todos, habits, reminders) : null),
+    [goal, todos, habits, reminders],
+  );
+
+  // Empty state — nudge toward creating a goal.
+  if (!goal || !progress) {
+    return (
+      <Link
+        to="/goals"
+        className="relative flex items-center justify-center gap-3 rounded-xl border border-white/10 bg-white/5 px-5 py-4 transition-colors hover:border-white/20 hover:bg-white/[0.07]"
+      >
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/5">
+          <Trophy className="h-5 w-5 text-white/40" />
+        </div>
+        <div>
+          <p className="text-sm font-semibold text-white">No goals yet</p>
+          <p className="text-xs text-white/50">
+            Set a goal to track habits, tasks & reminders together
+          </p>
+        </div>
+        <span className="absolute right-5 top-1/2 flex -translate-y-1/2 items-center gap-1 text-xs font-medium text-sky-300">
+          Create goal <ArrowRight className="h-3.5 w-3.5" />
+        </span>
+      </Link>
+    );
+  }
+
+  const segments = [
+    {
+      label: "tasks",
+      value: progress.todos.total
+        ? `${progress.todos.done}/${progress.todos.total}`
+        : null,
+      color: "bg-emerald-400",
+    },
+    {
+      label: "habits",
+      value: progress.habits.count
+        ? `${Math.round(progress.habits.ratio * 100)}%`
+        : null,
+      color: "bg-fuchsia-400",
+    },
+    {
+      label: "reminders",
+      value: progress.reminders.total
+        ? `${progress.reminders.done}/${progress.reminders.total}`
+        : null,
+      color: "bg-amber-400",
+    },
+  ].filter((s) => s.value !== null);
+
+  return (
+    <div className="relative flex items-center justify-center gap-5 rounded-xl border border-white/10 bg-white/5 px-5 py-4">
+      <GoalRing percent={progress.percent} size={76} />
+
+      <div className="min-w-0 text-center">
+        <div className="mb-1 flex items-center justify-center gap-2">
+          <Trophy className="h-3.5 w-3.5 shrink-0 text-sky-300" />
+          <span className="text-[11px] font-medium uppercase tracking-wider text-white/40">
+            Goal in focus
+          </span>
+        </div>
+        <h3 className="truncate text-lg font-bold text-white">{goal.title}</h3>
+
+        <div className="mt-1.5 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-white/55">
+          {goal.targetDate && (
+            <span className="flex items-center gap-1">
+              <CalendarDays className="h-3 w-3" />
+              due {format(goal.targetDate, "MMM d")}
+            </span>
+          )}
+          {segments.map((s) => (
+            <span key={s.label} className="flex items-center gap-1.5">
+              <span className={`h-2 w-2 rounded-full ${s.color}`} />
+              {s.value} {s.label}
+            </span>
+          ))}
+          {progress.isEmpty && (
+            <span className="text-white/30">No items linked yet</span>
+          )}
+        </div>
+      </div>
+
+      <Link
+        to="/goals"
+        className="absolute right-5 top-4 flex items-center gap-1 text-xs font-medium text-sky-300 transition-colors hover:text-sky-200"
+      >
+        View all <ArrowRight className="h-3.5 w-3.5" />
+      </Link>
+    </div>
+  );
+}

--- a/src/componenets/Goals/GoalRing.tsx
+++ b/src/componenets/Goals/GoalRing.tsx
@@ -1,0 +1,67 @@
+interface GoalRingProps {
+  percent: number; // 0–100
+  size?: number; // px diameter
+  stroke?: number; // ring thickness
+  className?: string;
+}
+
+/**
+ * A circular progress ring. The percent is rendered in the center; the arc
+ * turns emerald once the goal is complete, otherwise sky-blue.
+ */
+export function GoalRing({
+  percent,
+  size = 72,
+  stroke = 7,
+  className = "",
+}: GoalRingProps) {
+  const clamped = Math.max(0, Math.min(100, percent));
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (clamped / 100) * circumference;
+  const done = clamped >= 100;
+
+  return (
+    <div
+      className={`relative shrink-0 ${className}`}
+      style={{ width: size, height: size }}
+    >
+      <svg width={size} height={size} className="-rotate-90">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          className="text-white/10"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          className={`transition-all duration-700 ease-out ${
+            done ? "text-emerald-400" : "text-sky-400"
+          }`}
+        />
+      </svg>
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span
+          className="font-bold text-white"
+          style={{ fontSize: size * 0.26 }}
+        >
+          {clamped}
+          <span className="text-white/50" style={{ fontSize: size * 0.16 }}>
+            %
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/componenets/Sidebar.tsx
+++ b/src/componenets/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Target,
   CheckSquare,
   Bell,
+  Trophy,
   Bot,
   ChevronLeft,
   ChevronRight,
@@ -138,6 +139,18 @@ export function Sidebar() {
                 variant="ghost"
                 size="icon"
                 className="h-10 w-10"
+                title="Goals"
+                asChild
+              >
+                <Link to="/goals">
+                  <Trophy className="h-5 w-5" />
+                </Link>
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10"
                 title="AI Assistant"
                 asChild
               >
@@ -206,6 +219,18 @@ export function Sidebar() {
                 <Link to="/reminder">
                   <Bell className="h-4 w-4 mr-2" />
                   Reminder
+                </Link>
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start px-0"
+                asChild
+              >
+                <Link to="/goals">
+                  <Trophy className="h-4 w-4 mr-2" />
+                  Goals
                 </Link>
               </Button>
 

--- a/src/lib/goalProgress.ts
+++ b/src/lib/goalProgress.ts
@@ -1,0 +1,71 @@
+import type { Todo } from "@/zustand/todoStore";
+import type { Habit } from "@/zustand/habbitStore";
+import type { Reminder } from "@/zustand/reminderStore";
+import type { Goal } from "@/zustand/goalStore";
+
+export type GoalProgress = {
+  percent: number; // 0–100, the headline number
+  todos: { done: number; total: number };
+  reminders: { done: number; total: number };
+  habits: { ratio: number; count: number }; // avg weekly ratio across habits
+  isEmpty: boolean; // no trackable items linked yet
+};
+
+/**
+ * Derives a goal's progress from its linked items. Each unit (one todo, one
+ * reminder, one habit) is weighted equally:
+ *  - a todo counts as done when its status is "Done" ("Kill" is excluded
+ *    from the denominator entirely — abandoned, not pending),
+ *  - a reminder counts when completed,
+ *  - a habit contributes its current-week ratio (0–1), since a habit is never
+ *    truly "done" — it's recurring.
+ *
+ * Pass the items already filtered to this goal.
+ */
+export function computeGoalProgress(
+  todos: Todo[],
+  habits: Habit[],
+  reminders: Reminder[],
+): GoalProgress {
+  const liveTodos = todos.filter((t) => t.status !== "Kill");
+  const todosDone = liveTodos.filter((t) => t.status === "Done").length;
+  const remindersDone = reminders.filter((r) => r.completed).length;
+
+  const habitRatios = habits.map(
+    (h) => h.completions.filter(Boolean).length / 7,
+  );
+  const habitScore = habitRatios.reduce((sum, r) => sum + r, 0);
+
+  const completed = todosDone + remindersDone + habitScore;
+  const total = liveTodos.length + reminders.length + habits.length;
+
+  return {
+    percent: total === 0 ? 0 : Math.round((completed / total) * 100),
+    todos: { done: todosDone, total: liveTodos.length },
+    reminders: { done: remindersDone, total: reminders.length },
+    habits: {
+      ratio: habits.length ? habitScore / habits.length : 0,
+      count: habits.length,
+    },
+    isEmpty: total === 0,
+  };
+}
+
+/**
+ * Resolves a goal's linked item ids against the full store collections and
+ * returns its computed progress. Habit ids may be integers (prod) or UUID
+ * strings (mock), so they're matched by string.
+ */
+export function progressForGoal(
+  goal: Goal,
+  todos: Todo[],
+  habits: Habit[],
+  reminders: Reminder[],
+): GoalProgress {
+  const habitIdSet = new Set(goal.habitIds.map(String));
+  return computeGoalProgress(
+    todos.filter((t) => goal.todoIds.includes(t.id)),
+    habits.filter((h) => habitIdSet.has(String(h.id))),
+    reminders.filter((r) => goal.reminderIds.includes(r.id)),
+  );
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ReminderRouteImport } from './routes/reminder'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as HabitTrackerRouteImport } from './routes/habit-tracker'
+import { Route as GoalsRouteImport } from './routes/goals'
 import { Route as FocusRouteImport } from './routes/focus'
 import { Route as AgentRouteImport } from './routes/agent'
 import { Route as IndexRouteImport } from './routes/index'
@@ -43,6 +44,11 @@ const HabitTrackerRoute = HabitTrackerRouteImport.update({
   path: '/habit-tracker',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GoalsRoute = GoalsRouteImport.update({
+  id: '/goals',
+  path: '/goals',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const FocusRoute = FocusRouteImport.update({
   id: '/focus',
   path: '/focus',
@@ -63,6 +69,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/agent': typeof AgentRoute
   '/focus': typeof FocusRoute
+  '/goals': typeof GoalsRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
   '/reminder': typeof ReminderRoute
@@ -73,6 +80,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/agent': typeof AgentRoute
   '/focus': typeof FocusRoute
+  '/goals': typeof GoalsRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
   '/reminder': typeof ReminderRoute
@@ -84,6 +92,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/agent': typeof AgentRoute
   '/focus': typeof FocusRoute
+  '/goals': typeof GoalsRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
   '/reminder': typeof ReminderRoute
@@ -96,6 +105,7 @@ export interface FileRouteTypes {
     | '/'
     | '/agent'
     | '/focus'
+    | '/goals'
     | '/habit-tracker'
     | '/login'
     | '/reminder'
@@ -106,6 +116,7 @@ export interface FileRouteTypes {
     | '/'
     | '/agent'
     | '/focus'
+    | '/goals'
     | '/habit-tracker'
     | '/login'
     | '/reminder'
@@ -116,6 +127,7 @@ export interface FileRouteTypes {
     | '/'
     | '/agent'
     | '/focus'
+    | '/goals'
     | '/habit-tracker'
     | '/login'
     | '/reminder'
@@ -127,6 +139,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AgentRoute: typeof AgentRoute
   FocusRoute: typeof FocusRoute
+  GoalsRoute: typeof GoalsRoute
   HabitTrackerRoute: typeof HabitTrackerRoute
   LoginRoute: typeof LoginRoute
   ReminderRoute: typeof ReminderRoute
@@ -171,6 +184,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HabitTrackerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/goals': {
+      id: '/goals'
+      path: '/goals'
+      fullPath: '/goals'
+      preLoaderRoute: typeof GoalsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/focus': {
       id: '/focus'
       path: '/focus'
@@ -199,6 +219,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AgentRoute: AgentRoute,
   FocusRoute: FocusRoute,
+  GoalsRoute: GoalsRoute,
   HabitTrackerRoute: HabitTrackerRoute,
   LoginRoute: LoginRoute,
   ReminderRoute: ReminderRoute,

--- a/src/routes/goals.tsx
+++ b/src/routes/goals.tsx
@@ -1,0 +1,329 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useEffect, useMemo, useState } from "react";
+import { format } from "date-fns";
+import {
+  Plus,
+  Trophy,
+  CalendarDays,
+  Pencil,
+  Trash2,
+  Archive,
+  ArchiveRestore,
+  CheckSquare,
+  Repeat,
+  Bell,
+} from "lucide-react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { isAuthenticated } from "@/lib/authVerification";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useGoalStore, type Goal } from "@/zustand/goalStore";
+import { useTodoStore } from "@/zustand/todoStore";
+import { useHabitStore } from "@/zustand/habbitStore";
+import { useReminderStore } from "@/zustand/reminderStore";
+import { progressForGoal } from "@/lib/goalProgress";
+import { GoalFormDialog } from "@/componenets/Goals/GoalFormDialog";
+
+export const Route = createFileRoute("/goals")({
+  component: RouteComponent,
+  beforeLoad: async () => {
+    if (!isAuthenticated()) {
+      throw redirect({ to: "/login" });
+    }
+  },
+});
+
+const STATUS_STYLES: Record<Goal["status"], string> = {
+  active: "bg-sky-500/15 text-sky-300 border-sky-500/30",
+  completed: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+  archived: "bg-white/10 text-white/50 border-white/15",
+};
+const STATUS_DOT: Record<Goal["status"], string> = {
+  active: "bg-sky-400",
+  completed: "bg-emerald-400",
+  archived: "bg-white/30",
+};
+
+function GoalRow({
+  goal,
+  onEdit,
+  onDelete,
+}: {
+  goal: Goal;
+  onEdit: (goal: Goal) => void;
+  onDelete: (goal: Goal) => void;
+}) {
+  const { updateGoal } = useGoalStore();
+  const todos = useTodoStore((s) => s.todos);
+  const habits = useHabitStore((s) => s.habits);
+  const reminders = useReminderStore((s) => s.reminders);
+
+  const progress = useMemo(
+    () => progressForGoal(goal, todos, habits, reminders),
+    [goal, todos, habits, reminders],
+  );
+
+  // Send the full current goal so a status-only change can't drop other
+  // fields (the prod backend overwrites any field present in the payload).
+  const toggleArchive = () =>
+    updateGoal(goal.id, {
+      title: goal.title,
+      description: goal.description,
+      targetDate: goal.targetDate,
+      status: goal.status === "archived" ? "active" : "archived",
+      todoIds: goal.todoIds,
+      habitIds: goal.habitIds,
+      reminderIds: goal.reminderIds,
+    });
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATUS_DOT[goal.status]}`} />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-white">
+              {goal.title}
+            </p>
+            {goal.description && (
+              <p className="truncate text-xs text-white/50">
+                {goal.description}
+              </p>
+            )}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Badge
+            variant="outline"
+            className={`h-5 px-2 text-[10px] capitalize ${STATUS_STYLES[goal.status]}`}
+          >
+            {goal.status}
+          </Badge>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-white/50 hover:text-white"
+            title="Edit"
+            onClick={() => onEdit(goal)}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-white/50 hover:text-white"
+            title={goal.status === "archived" ? "Unarchive" : "Archive"}
+            onClick={toggleArchive}
+          >
+            {goal.status === "archived" ? (
+              <ArchiveRestore className="h-3.5 w-3.5" />
+            ) : (
+              <Archive className="h-3.5 w-3.5" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-white/50 hover:text-red-400"
+            title="Delete"
+            onClick={() => onDelete(goal)}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="mt-3 flex items-center gap-3">
+        <div className="h-2 flex-1 overflow-hidden rounded-full bg-white/10">
+          <div
+            className={`h-full rounded-full transition-all duration-500 ${
+              progress.percent >= 100 ? "bg-emerald-400" : "bg-sky-400"
+            }`}
+            style={{ width: `${progress.percent}%` }}
+          />
+        </div>
+        <span className="w-10 text-right text-sm font-semibold text-white">
+          {progress.percent}%
+        </span>
+      </div>
+
+      {/* Meta row */}
+      <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-white/50">
+        {goal.targetDate && (
+          <span className="flex items-center gap-1">
+            <CalendarDays className="h-3 w-3" />
+            due {format(goal.targetDate, "MMM d, yyyy")}
+          </span>
+        )}
+        {progress.todos.total > 0 && (
+          <span className="flex items-center gap-1">
+            <CheckSquare className="h-3 w-3 text-emerald-400" />
+            {progress.todos.done}/{progress.todos.total} tasks
+          </span>
+        )}
+        {progress.habits.count > 0 && (
+          <span className="flex items-center gap-1">
+            <Repeat className="h-3 w-3 text-fuchsia-400" />
+            {Math.round(progress.habits.ratio * 100)}% habits
+          </span>
+        )}
+        {progress.reminders.total > 0 && (
+          <span className="flex items-center gap-1">
+            <Bell className="h-3 w-3 text-amber-400" />
+            {progress.reminders.done}/{progress.reminders.total} reminders
+          </span>
+        )}
+        {progress.isEmpty && (
+          <span className="text-white/30">No items linked yet</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RouteComponent() {
+  useDocumentTitle("Goals");
+
+  const {
+    goals,
+    fetchGoals,
+    deleteGoal,
+    isLoading: goalsLoading,
+    hasInitialized: goalsReady,
+  } = useGoalStore();
+  const { fetchTodos } = useTodoStore();
+  const { fetchHabits } = useHabitStore();
+  const { fetchReminders } = useReminderStore();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<Goal | null>(null);
+  const [deleting, setDeleting] = useState<Goal | null>(null);
+
+  useEffect(() => {
+    fetchGoals();
+    fetchTodos();
+    fetchHabits();
+    fetchReminders();
+  }, [fetchGoals, fetchTodos, fetchHabits, fetchReminders]);
+
+  const sorted = useMemo(
+    () =>
+      [...goals].sort((a, b) => {
+        if (a.status !== b.status) {
+          const order = { active: 0, completed: 1, archived: 2 } as const;
+          return order[a.status] - order[b.status];
+        }
+        const at = a.targetDate ? a.targetDate.getTime() : Infinity;
+        const bt = b.targetDate ? b.targetDate.getTime() : Infinity;
+        return at - bt;
+      }),
+    [goals],
+  );
+
+  const openCreate = () => {
+    setEditing(null);
+    setDialogOpen(true);
+  };
+  const openEdit = (goal: Goal) => {
+    setEditing(goal);
+    setDialogOpen(true);
+  };
+
+  const isLoading = !goalsReady && goalsLoading;
+
+  return (
+    <div className="mx-auto max-w-4xl p-2 md:p-4">
+      <header className="mb-6 flex items-center justify-between gap-3">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-white md:text-3xl">
+            <Trophy className="h-6 w-6 text-sky-300" />
+            Goals
+          </h1>
+          <p className="mt-1 text-sm text-white/60">
+            Track your habits, tasks & reminders toward what matters.
+          </p>
+        </div>
+        <Button onClick={openCreate} className="shrink-0">
+          <Plus className="mr-1.5 h-4 w-4" />
+          New Goal
+        </Button>
+      </header>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[...Array(3)].map((_, i) => (
+            <Skeleton key={i} className="h-28 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : sorted.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-white/15 bg-white/[0.02] py-16 text-center">
+          <Trophy className="mx-auto mb-3 h-10 w-10 text-white/20" />
+          <p className="text-sm font-medium text-white">No goals yet</p>
+          <p className="mt-1 text-xs text-white/50">
+            Create a goal and link the habits, tasks, and reminders that drive
+            it.
+          </p>
+          <Button onClick={openCreate} className="mt-4">
+            <Plus className="mr-1.5 h-4 w-4" />
+            New Goal
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {sorted.map((goal) => (
+            <GoalRow
+              key={goal.id}
+              goal={goal}
+              onEdit={openEdit}
+              onDelete={setDeleting}
+            />
+          ))}
+        </div>
+      )}
+
+      <GoalFormDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        goal={editing}
+      />
+
+      <AlertDialog
+        open={Boolean(deleting)}
+        onOpenChange={(o) => !o && setDeleting(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete goal?</AlertDialogTitle>
+            <AlertDialogDescription>
+              "{deleting?.title}" will be removed. Your linked tasks, habits,
+              and reminders are kept — only the goal and its links are deleted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deleting) deleteGoal(deleting.id);
+                setDeleting(null);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { isAuthenticated } from "@/lib/authVerification";
 import { useTodoStore } from "@/zustand/todoStore";
 import { useReminderStore } from "@/zustand/reminderStore";
 import { useHabitStore } from "@/zustand/habbitStore";
+import { useGoalStore } from "@/zustand/goalStore";
 import { useModeStore } from "@/zustand/modeStore";
 import { getTodoStats, getHabitStats } from "@/lib/dashboardStats";
 import { StatCard } from "@/componenets/Dashboard/StatCard";
@@ -14,6 +15,7 @@ import { TodoStatusChart } from "@/componenets/Dashboard/TodoStatusChart";
 import { HabitProgressChart } from "@/componenets/Dashboard/HabitProgressChart";
 import { UpcomingAgenda } from "@/componenets/Dashboard/UpcomingAgenda";
 import { MiniReminderCalendar } from "@/componenets/Dashboard/MiniReminderCalendar";
+import { GoalHero } from "@/componenets/Goals/GoalHero";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/")({
@@ -119,6 +121,7 @@ function RouteComponent() {
     hasInitialized: remindersReady,
   } = useReminderStore();
   const { habits, fetchHabits, isLoading: habitsLoading, hasInitialized: habitsReady } = useHabitStore();
+  const { goals, fetchGoals, isLoading: goalsLoading, hasInitialized: goalsReady } = useGoalStore();
   const { currentFocusSessionCount, fetchFocusSessionCount } =
     useModeStore() as {
       currentFocusSessionCount: number;
@@ -129,13 +132,15 @@ function RouteComponent() {
     fetchTodos();
     fetchReminders();
     fetchHabits();
+    fetchGoals();
     fetchFocusSessionCount();
-  }, [fetchTodos, fetchReminders, fetchHabits, fetchFocusSessionCount]);
+  }, [fetchTodos, fetchReminders, fetchHabits, fetchGoals, fetchFocusSessionCount]);
 
   const isLoading =
     (!todosReady && todosLoading) ||
     (!remindersReady && remindersLoading) ||
-    (!habitsReady && habitsLoading);
+    (!habitsReady && habitsLoading) ||
+    (!goalsReady && goalsLoading);
 
   const todoStats = useMemo(() => getTodoStats(todos), [todos]);
   const habitStats = useMemo(() => getHabitStats(habits), [habits]);
@@ -190,6 +195,16 @@ function RouteComponent() {
           value={`${habitStats.averageCompletion}%`}
           sub={`${habitStats.todayCompleted}/${habitStats.count} done today`}
           accent="text-fuchsia-400"
+        />
+      </section>
+
+      {/* Goal in focus */}
+      <section className="mb-6 md:mb-8">
+        <GoalHero
+          goals={goals}
+          todos={todos}
+          habits={habits}
+          reminders={reminders}
         />
       </section>
 

--- a/src/zustand/goalStore.ts
+++ b/src/zustand/goalStore.ts
@@ -1,0 +1,159 @@
+import { API_BASE_URL } from "@/constants/data";
+import { getAuthToken } from "@/lib/authHelpers";
+import { create } from "zustand";
+
+export type GoalStatus = "active" | "completed" | "archived";
+
+export type Goal = {
+  id: number;
+  title: string;
+  description?: string | null;
+  targetDate: Date | null;
+  status: GoalStatus;
+  // Ids of the items linked to this goal (many-to-many). Habit ids may be
+  // integers (prod backend) or UUID strings (local mock), so allow both.
+  todoIds: number[];
+  habitIds: Array<number | string>;
+  reminderIds: number[];
+  userId?: number;
+};
+
+type ApiGoal = {
+  id: number;
+  title: string;
+  description?: string | null;
+  targetDate: string | null;
+  status: GoalStatus;
+  todoIds: number[];
+  habitIds: Array<number | string>;
+  reminderIds: number[];
+  userId?: number;
+};
+
+export type GoalInput = {
+  title: string;
+  description?: string | null;
+  targetDate?: Date | null;
+  status?: GoalStatus;
+  todoIds?: number[];
+  habitIds?: Array<number | string>;
+  reminderIds?: number[];
+};
+
+const serializeDate = (date: Date): string => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+};
+
+const fromApi = (g: ApiGoal): Goal => ({
+  id: Number(g.id),
+  title: g.title,
+  description: g.description ?? null,
+  targetDate: g.targetDate ? new Date(g.targetDate) : null,
+  status: g.status,
+  todoIds: g.todoIds ?? [],
+  habitIds: g.habitIds ?? [],
+  reminderIds: g.reminderIds ?? [],
+  userId: g.userId,
+});
+
+const authHeaders = (): HeadersInit => ({
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${getAuthToken()}`,
+});
+
+const toBody = (input: GoalInput) => ({
+  ...input,
+  targetDate: input.targetDate ? serializeDate(input.targetDate) : null,
+});
+
+type GoalStore = {
+  goals: Goal[];
+  isLoading: boolean;
+  hasInitialized: boolean;
+  fetchGoals: () => Promise<void>;
+  addGoal: (goal: GoalInput) => Promise<void>;
+  updateGoal: (id: number, updates: GoalInput) => Promise<void>;
+  deleteGoal: (id: number) => Promise<void>;
+  clearGoals: () => void;
+  getGoalById: (id: number) => Goal | undefined;
+};
+
+export const useGoalStore = create<GoalStore>()((set, get) => ({
+  goals: [],
+  isLoading: false,
+  hasInitialized: false,
+
+  fetchGoals: async () => {
+    set({ isLoading: true });
+    try {
+      const res = await fetch(`${API_BASE_URL}/goal`, {
+        method: "GET",
+        headers: authHeaders(),
+      });
+      if (!res.ok) throw new Error("Failed to fetch goals");
+      const data: ApiGoal[] = await res.json();
+      set({
+        goals: data.map(fromApi),
+        isLoading: false,
+        hasInitialized: true,
+      });
+    } catch (e) {
+      console.error("Error fetching goals:", e);
+      set({ goals: [], isLoading: false, hasInitialized: true });
+    }
+  },
+
+  addGoal: async (goal) => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/goal`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(toBody(goal)),
+      });
+      if (!res.ok) throw new Error("Failed to create goal");
+      const created = fromApi(await res.json());
+      set((state) => ({ goals: [...state.goals, created] }));
+    } catch (e) {
+      console.error("Error creating goal:", e);
+      throw e;
+    }
+  },
+
+  updateGoal: async (id, updates) => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/goal/${id}`, {
+        method: "PUT",
+        headers: authHeaders(),
+        body: JSON.stringify(toBody(updates)),
+      });
+      if (!res.ok) throw new Error("Failed to update goal");
+      const updated = fromApi(await res.json());
+      set((state) => ({
+        goals: state.goals.map((g) => (g.id === id ? updated : g)),
+      }));
+    } catch (e) {
+      console.error("Error updating goal:", e);
+      throw e;
+    }
+  },
+
+  deleteGoal: async (id) => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/goal/${id}`, {
+        method: "DELETE",
+        headers: authHeaders(),
+      });
+      if (!res.ok) throw new Error("Failed to delete goal");
+      set((state) => ({ goals: state.goals.filter((g) => g.id !== id) }));
+    } catch (e) {
+      console.error("Error deleting goal:", e);
+      throw e;
+    }
+  },
+
+  clearGoals: () => set({ goals: [], hasInitialized: false }),
+  getGoalById: (id) => get().goals.find((g) => g.id === id),
+}));

--- a/test-backend/index.js
+++ b/test-backend/index.js
@@ -354,6 +354,145 @@ app.delete("/reminder/:id", auth, async (req, res) => {
   }
 });
 
+// ── Goals ─────────────────────────────────────────────────────────────────────
+
+// Format a pg DATE (returned as a local-midnight Date) as YYYY-MM-DD using
+// local calendar parts. Using toISOString here would shift the day in
+// timezones ahead of UTC, mirroring the bug the reminder code avoids.
+function formatDateLocal(d) {
+  if (!d) return null;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+// Enrich goal rows with the ids of their linked todos / habits / reminders so
+// the frontend can compute progress from items it already has loaded.
+async function attachGoalLinks(goalRows) {
+  if (goalRows.length === 0) return [];
+  const ids = goalRows.map((g) => g.id);
+  const [td, hb, rm] = await Promise.all([
+    pool.query("SELECT goal_id, todo_id FROM goal_todos WHERE goal_id = ANY($1)", [ids]),
+    pool.query("SELECT goal_id, habit_id FROM goal_habits WHERE goal_id = ANY($1)", [ids]),
+    pool.query("SELECT goal_id, reminder_id FROM goal_reminders WHERE goal_id = ANY($1)", [ids]),
+  ]);
+  return goalRows.map((g) => ({
+    id: g.id,
+    title: g.title,
+    description: g.description ?? null,
+    targetDate: formatDateLocal(g.target_date),
+    status: g.status,
+    todoIds: td.rows.filter((r) => r.goal_id === g.id).map((r) => r.todo_id),
+    habitIds: hb.rows.filter((r) => r.goal_id === g.id).map((r) => r.habit_id),
+    reminderIds: rm.rows.filter((r) => r.goal_id === g.id).map((r) => r.reminder_id),
+    userId: g.user_id,
+  }));
+}
+
+// Replace the link rows for a goal. `undefined` arrays are left untouched; an
+// empty array clears that link type.
+async function setGoalLinks(goalId, { todoIds, habitIds, reminderIds }) {
+  if (todoIds !== undefined) {
+    await pool.query("DELETE FROM goal_todos WHERE goal_id = $1", [goalId]);
+    for (const todoId of todoIds) {
+      await pool.query(
+        "INSERT INTO goal_todos (goal_id, todo_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        [goalId, todoId]
+      );
+    }
+  }
+  if (habitIds !== undefined) {
+    await pool.query("DELETE FROM goal_habits WHERE goal_id = $1", [goalId]);
+    for (const habitId of habitIds) {
+      await pool.query(
+        "INSERT INTO goal_habits (goal_id, habit_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        [goalId, habitId]
+      );
+    }
+  }
+  if (reminderIds !== undefined) {
+    await pool.query("DELETE FROM goal_reminders WHERE goal_id = $1", [goalId]);
+    for (const reminderId of reminderIds) {
+      await pool.query(
+        "INSERT INTO goal_reminders (goal_id, reminder_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        [goalId, reminderId]
+      );
+    }
+  }
+}
+
+app.get("/goal", auth, async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      "SELECT * FROM goals WHERE user_id = $1 ORDER BY created_at DESC",
+      [req.userId]
+    );
+    res.json(await attachGoalLinks(rows));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post("/goal", auth, async (req, res) => {
+  try {
+    const { title, description, targetDate, status, todoIds, habitIds, reminderIds } =
+      req.body;
+    const { rows } = await pool.query(
+      "INSERT INTO goals (title, description, target_date, status, user_id) VALUES ($1, $2, $3, $4, $5) RETURNING *",
+      [title, description ?? null, targetDate || null, status || "active", req.userId]
+    );
+    const goal = rows[0];
+    await setGoalLinks(goal.id, { todoIds, habitIds, reminderIds });
+    const [withLinks] = await attachGoalLinks([goal]);
+    res.json(withLinks);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.put("/goal/:id", auth, async (req, res) => {
+  try {
+    const { title, description, targetDate, status, todoIds, habitIds, reminderIds } =
+      req.body;
+    const { rows } = await pool.query(
+      `UPDATE goals SET
+        title = COALESCE($1, title),
+        description = COALESCE($2, description),
+        target_date = COALESCE($3, target_date),
+        status = COALESCE($4, status)
+       WHERE id = $5 AND user_id = $6 RETURNING *`,
+      [
+        title ?? null,
+        description ?? null,
+        targetDate || null,
+        status ?? null,
+        req.params.id,
+        req.userId,
+      ]
+    );
+    if (!rows[0]) return res.status(404).json({ message: "Not found" });
+    await setGoalLinks(rows[0].id, { todoIds, habitIds, reminderIds });
+    const [withLinks] = await attachGoalLinks([rows[0]]);
+    res.json(withLinks);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.delete("/goal/:id", auth, async (req, res) => {
+  try {
+    // Link rows are removed by the ON DELETE CASCADE on the join tables.
+    await pool.query("DELETE FROM goals WHERE id = $1 AND user_id = $2", [
+      req.params.id,
+      req.userId,
+    ]);
+    res.json({ message: "Deleted" });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
 // ── Timer modes ───────────────────────────────────────────────────────────────
 
 app.get("/timer", auth, async (req, res) => {

--- a/test-backend/seed.js
+++ b/test-backend/seed.js
@@ -82,6 +82,37 @@ async function seed() {
       date DATE DEFAULT CURRENT_DATE,
       user_id INTEGER REFERENCES users(id) ON DELETE CASCADE
     );
+
+    CREATE TABLE IF NOT EXISTS goals (
+      id SERIAL PRIMARY KEY,
+      title VARCHAR(255) NOT NULL,
+      description TEXT,
+      target_date DATE,
+      status VARCHAR(20) DEFAULT 'active',
+      user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+
+    -- Join tables (many goals ↔ many items). Both FKs cascade so deleting a
+    -- goal or an item only removes the link rows. Note habit_id is UUID here
+    -- because the mock's hobbies table uses UUID primary keys.
+    CREATE TABLE IF NOT EXISTS goal_todos (
+      goal_id INTEGER REFERENCES goals(id) ON DELETE CASCADE,
+      todo_id INTEGER REFERENCES todos(id) ON DELETE CASCADE,
+      PRIMARY KEY (goal_id, todo_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS goal_habits (
+      goal_id INTEGER REFERENCES goals(id) ON DELETE CASCADE,
+      habit_id UUID REFERENCES hobbies(id) ON DELETE CASCADE,
+      PRIMARY KEY (goal_id, habit_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS goal_reminders (
+      goal_id INTEGER REFERENCES goals(id) ON DELETE CASCADE,
+      reminder_id INTEGER REFERENCES reminders(id) ON DELETE CASCADE,
+      PRIMARY KEY (goal_id, reminder_id)
+    );
   `);
 
   // Skip seeding if user already exists


### PR DESCRIPTION
## Summary
Adds a **Goals** feature: users set a goal and link the habits, tasks, and reminders that drive it, then track an aggregated progress percentage. Surfaced as a dedicated `/goals` page plus a spotlight hero on the dashboard.



## Changes
- **`goalStore`** — CRUD + item-linking against the `/goal` API.
- **`goalProgress`** — shared, derived progress: todos `Done`, reminders `completed`, habits' current-week ratio; equal-weighted, `Kill` todos excluded. Habit ids matched as strings so it works with both integer (prod) and UUID (local mock) backends.
- **`/goals` page** — list with progress bars, status badges, and edit / archive / delete; a create/edit dialog (`GoalFormDialog`) to set details and check off linked items.
- **Dashboard hero** (`GoalHero` + `GoalRing`) — full-width container with centered content, spotlighting the nearest-deadline active goal; ring + per-type breakdown + "View all".
- **Sidebar** — Goals nav entry.
- **`test-backend` (mock)** — mirrored goal endpoints + join tables so the feature runs locally without deploying.
