### PR TITLE
test: Vitest coverage for goals (progress + store) + date fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,8 @@
         "tw-animate-css": "1.3.6",
         "typescript": "~5.8.3",
         "typescript-eslint": "8.39.0",
-        "vite": "7.1.0"
+        "vite": "7.1.0",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1300,9 +1301,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -3332,6 +3333,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -3403,6 +3415,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3793,6 +3812,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4031,6 +4163,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -4260,6 +4402,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4941,6 +5093,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5301,6 +5460,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5316,6 +5485,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6818,12 +6997,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-table": {
@@ -7920,6 +8099,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8050,6 +8243,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8925,6 +9125,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/solid-js": {
       "version": "1.9.9",
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.9.tgz",
@@ -8964,6 +9171,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -9212,14 +9433,31 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9229,10 +9467,13 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -9243,9 +9484,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -9253,6 +9494,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9867,6 +10118,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -9977,6 +10331,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "npx prettier . --write",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -59,6 +61,7 @@
     "tw-animate-css": "1.3.6",
     "typescript": "~5.8.3",
     "typescript-eslint": "8.39.0",
-    "vite": "7.1.0"
+    "vite": "7.1.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/src/lib/goalProgress.test.ts
+++ b/src/lib/goalProgress.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import { computeGoalProgress, progressForGoal } from "./goalProgress";
+import type { Todo } from "@/zustand/todoStore";
+import type { Habit } from "@/zustand/habbitStore";
+import type { Reminder } from "@/zustand/reminderStore";
+import type { Goal } from "@/zustand/goalStore";
+
+// ── Builders ────────────────────────────────────────────────────────────────
+
+const todo = (id: number, status: Todo["status"]): Todo => ({
+  id,
+  title: `todo ${id}`,
+  description: "",
+  status,
+  dueDate: null,
+});
+
+const reminder = (id: number, completed: boolean): Reminder => ({
+  id,
+  title: `reminder ${id}`,
+  date: new Date(2026, 0, 1),
+  time: "10:00",
+  priority: "low",
+  completed,
+});
+
+// `doneDays` = how many of the 7 weekday slots are completed.
+const habit = (id: number | string, doneDays: number): Habit => ({
+  id: id as unknown as string,
+  name: `habit ${id}`,
+  completions: Array.from({ length: 7 }, (_, i) => i < doneDays) as Habit["completions"],
+});
+
+// ── computeGoalProgress ───────────────────────────────────────────────────────
+
+describe("computeGoalProgress", () => {
+  it("reports an empty goal with no linked items", () => {
+    const p = computeGoalProgress([], [], []);
+    expect(p).toEqual({
+      percent: 0,
+      todos: { done: 0, total: 0 },
+      reminders: { done: 0, total: 0 },
+      habits: { ratio: 0, count: 0 },
+      isEmpty: true,
+    });
+  });
+
+  it("counts a single completed todo as 100%", () => {
+    const p = computeGoalProgress([todo(1, "Done")], [], []);
+    expect(p.percent).toBe(100);
+    expect(p.todos).toEqual({ done: 1, total: 1 });
+    expect(p.isEmpty).toBe(false);
+  });
+
+  it("treats TODO / In Progress as not done", () => {
+    const p = computeGoalProgress([todo(1, "TODO"), todo(2, "In Progress")], [], []);
+    expect(p.percent).toBe(0);
+    expect(p.todos).toEqual({ done: 0, total: 2 });
+  });
+
+  it("excludes 'Kill' todos from both numerator and denominator", () => {
+    // 1 done + 1 killed → killed is ignored, so 1/1 = 100%, not 1/2 = 50%.
+    const p = computeGoalProgress([todo(1, "Done"), todo(2, "Kill")], [], []);
+    expect(p.percent).toBe(100);
+    expect(p.todos).toEqual({ done: 1, total: 1 });
+  });
+
+  it("counts completed reminders", () => {
+    const p = computeGoalProgress(
+      [],
+      [],
+      [reminder(1, true), reminder(2, false), reminder(3, false)],
+    );
+    expect(p.reminders).toEqual({ done: 1, total: 3 });
+    expect(p.percent).toBe(33); // round(1/3 * 100)
+  });
+
+  it("scores a habit by its current-week completion ratio", () => {
+    // one habit at 4/7 days → 57% (round(4/7*100))
+    const p = computeGoalProgress([], [habit(1, 4)], []);
+    expect(p.habits).toEqual({ ratio: 4 / 7, count: 1 });
+    expect(p.percent).toBe(57);
+  });
+
+  it("averages the ratio across multiple habits", () => {
+    const p = computeGoalProgress([], [habit(1, 7), habit(2, 0)], []);
+    // (1.0 + 0) / 2 contributions over 2 habits → 50%
+    expect(p.percent).toBe(50);
+    expect(p.habits.ratio).toBe(0.5);
+    expect(p.habits.count).toBe(2);
+  });
+
+  it("blends todos, reminders, and habits with equal weight", () => {
+    // todo done (1) + reminder done (1) + habit 7/7 (1) over 3 units = 100%
+    const p = computeGoalProgress(
+      [todo(1, "Done")],
+      [habit(1, 7)],
+      [reminder(1, true)],
+    );
+    expect(p.percent).toBe(100);
+  });
+
+  it("computes a realistic partial blend", () => {
+    // todosDone=1 (of 2 live), remindersDone=1 (of 2), habitScore=0 (0/7 habit)
+    // completed = 1 + 1 + 0 = 2; total = 2 + 2 + 1 = 5 → 40%
+    const p = computeGoalProgress(
+      [todo(1, "Done"), todo(2, "TODO")],
+      [habit(1, 0)],
+      [reminder(1, true), reminder(2, false)],
+    );
+    expect(p.percent).toBe(40);
+    expect(p.todos.total).toBe(2);
+  });
+
+  // ── Edge cases worth flagging ──────────────────────────────────────────────
+
+  it("EDGE: a goal linked only to 'Kill' todos reports as empty", () => {
+    // All linked todos are abandoned → total collapses to 0, so the UI shows
+    // "No items linked yet" even though items ARE linked. Documents current
+    // behavior; see notes for the recommended fix.
+    const p = computeGoalProgress([todo(1, "Kill"), todo(2, "Kill")], [], []);
+    expect(p.isEmpty).toBe(true);
+    expect(p.percent).toBe(0);
+  });
+
+  it("EDGE: Math.round can report 100% before genuine completion", () => {
+    // 199 of 200 reminders done = 99.5% → rounds UP to 100. A future
+    // auto-complete keyed on percent === 100 would fire one item early.
+    const reminders = Array.from({ length: 200 }, (_, i) => reminder(i, i < 199));
+    const p = computeGoalProgress([], [], reminders);
+    expect(p.percent).toBe(100);
+    expect(p.reminders.done).toBe(199); // ...but not actually all done
+  });
+
+  it("EDGE: tiny progress rounds down to 0%", () => {
+    // 1 of 300 done = 0.33% → rounds to 0, looks like no progress.
+    const reminders = Array.from({ length: 300 }, (_, i) => reminder(i, i < 1));
+    const p = computeGoalProgress([], [], reminders);
+    expect(p.percent).toBe(0);
+    expect(p.reminders.done).toBe(1);
+  });
+});
+
+// ── progressForGoal (id resolution) ───────────────────────────────────────────
+
+const makeGoal = (over: Partial<Goal>): Goal => ({
+  id: 1,
+  title: "g",
+  description: null,
+  targetDate: null,
+  status: "active",
+  todoIds: [],
+  habitIds: [],
+  reminderIds: [],
+  ...over,
+});
+
+describe("progressForGoal", () => {
+  it("resolves only the linked items, ignoring the rest", () => {
+    const todos = [todo(1, "Done"), todo(2, "TODO"), todo(3, "Done")];
+    const goal = makeGoal({ todoIds: [1, 2] }); // not 3
+    const p = progressForGoal(goal, todos, [], []);
+    expect(p.todos).toEqual({ done: 1, total: 2 });
+  });
+
+  it("matches habit ids whether they are integers (prod) or UUIDs (mock)", () => {
+    const intHabit = habit(5, 7);
+    const uuidHabit = habit("a1b2-uuid", 0);
+    // goal stores one as a number and one as a string — both should match.
+    const goal = makeGoal({ habitIds: [5, "a1b2-uuid"] });
+    const p = progressForGoal(goal, [], [intHabit, uuidHabit], []);
+    expect(p.habits.count).toBe(2);
+    expect(p.habits.ratio).toBe(0.5); // (1.0 + 0) / 2
+  });
+
+  it("matches a numeric habit id stored as a string and vice versa", () => {
+    const h = habit(7, 7);
+    const goal = makeGoal({ habitIds: ["7"] }); // string form of a numeric id
+    const p = progressForGoal(goal, [], [h], []);
+    expect(p.habits.count).toBe(1);
+  });
+
+  it("EDGE: silently drops stale links to deleted items", () => {
+    // goal references todo 99 which no longer exists → excluded, no crash.
+    const goal = makeGoal({ todoIds: [1, 99], reminderIds: [42] });
+    const p = progressForGoal(goal, [todo(1, "Done")], [], []);
+    expect(p.todos).toEqual({ done: 1, total: 1 });
+    expect(p.reminders).toEqual({ done: 0, total: 0 });
+  });
+
+  it("returns an empty result when nothing is linked", () => {
+    const p = progressForGoal(makeGoal({}), [todo(1, "Done")], [], []);
+    expect(p.isEmpty).toBe(true);
+  });
+});

--- a/src/zustand/goalStore.test.ts
+++ b/src/zustand/goalStore.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useGoalStore } from "./goalStore";
+
+// Mock auth so headers don't depend on real storage.
+vi.mock("@/lib/authHelpers", () => ({ getAuthToken: () => "test-token" }));
+
+const apiGoal = (over: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: "Ship v1",
+  description: "desc",
+  targetDate: "2026-07-31",
+  status: "active",
+  todoIds: [1, 2],
+  habitIds: [5, "uuid-9"],
+  reminderIds: [3],
+  userId: 1,
+  ...over,
+});
+
+const mockFetchOnce = (body: unknown, ok = true) => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    json: async () => body,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
+
+const reset = () =>
+  useGoalStore.setState({
+    goals: [],
+    isLoading: false,
+    hasInitialized: false,
+  });
+
+beforeEach(reset);
+afterEach(() => vi.unstubAllGlobals());
+
+describe("goalStore.fetchGoals", () => {
+  it("maps API goals into the store", async () => {
+    mockFetchOnce([apiGoal()]);
+    await useGoalStore.getState().fetchGoals();
+
+    const goals = useGoalStore.getState().goals;
+    expect(goals).toHaveLength(1);
+    expect(goals[0].title).toBe("Ship v1");
+    expect(goals[0].todoIds).toEqual([1, 2]);
+    expect(goals[0].habitIds).toEqual([5, "uuid-9"]);
+    expect(useGoalStore.getState().hasInitialized).toBe(true);
+  });
+
+  it("parses targetDate as a LOCAL date (no UTC off-by-one)", async () => {
+    mockFetchOnce([apiGoal({ targetDate: "2026-07-31" })]);
+    await useGoalStore.getState().fetchGoals();
+
+    const d = useGoalStore.getState().goals[0].targetDate!;
+    // Must be July 31 in local time regardless of the runner's timezone.
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(6); // 0-based → July
+    expect(d.getDate()).toBe(31);
+  });
+
+  it("keeps a null targetDate null", async () => {
+    mockFetchOnce([apiGoal({ targetDate: null })]);
+    await useGoalStore.getState().fetchGoals();
+    expect(useGoalStore.getState().goals[0].targetDate).toBeNull();
+  });
+
+  it("falls back to an empty list on a failed request", async () => {
+    mockFetchOnce({ error: "boom" }, false);
+    await useGoalStore.getState().fetchGoals();
+    expect(useGoalStore.getState().goals).toEqual([]);
+    expect(useGoalStore.getState().hasInitialized).toBe(true);
+  });
+});
+
+describe("goalStore.addGoal", () => {
+  it("appends the created goal and serializes the date as YYYY-MM-DD", async () => {
+    const fetchMock = mockFetchOnce(apiGoal());
+    await useGoalStore.getState().addGoal({
+      title: "Ship v1",
+      targetDate: new Date(2026, 6, 31), // local July 31
+      todoIds: [1, 2],
+    });
+
+    expect(useGoalStore.getState().goals).toHaveLength(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.targetDate).toBe("2026-07-31"); // local parts, not UTC-shifted
+  });
+});
+
+describe("goalStore.updateGoal / deleteGoal", () => {
+  it("replaces the updated goal in place", async () => {
+    useGoalStore.setState({ goals: [apiGoal() as never] });
+    mockFetchOnce(apiGoal({ title: "Renamed", status: "completed" }));
+
+    await useGoalStore.getState().updateGoal(1, { title: "Renamed" });
+    const g = useGoalStore.getState().goals[0];
+    expect(g.title).toBe("Renamed");
+    expect(g.status).toBe("completed");
+  });
+
+  it("EDGE: a partial update without targetDate sends null (would clear the date on prod)", async () => {
+    const fetchMock = mockFetchOnce(apiGoal());
+    // Caller omits targetDate — toBody still emits `targetDate: null`, which
+    // the prod backend treats as "set to null". Callers must pass the full
+    // goal for status-only changes (the archive action does).
+    await useGoalStore.getState().updateGoal(1, { title: "x", status: "archived" });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.targetDate).toBeNull();
+  });
+
+  it("removes a goal on delete", async () => {
+    useGoalStore.setState({ goals: [apiGoal() as never, apiGoal({ id: 2 }) as never] });
+    mockFetchOnce({ message: "Deleted" });
+
+    await useGoalStore.getState().deleteGoal(1);
+    const goals = useGoalStore.getState().goals;
+    expect(goals).toHaveLength(1);
+    expect(goals[0].id).toBe(2);
+  });
+
+  it("keeps state intact and rethrows when delete fails", async () => {
+    useGoalStore.setState({ goals: [apiGoal() as never] });
+    mockFetchOnce({ error: "no" }, false);
+
+    await expect(useGoalStore.getState().deleteGoal(1)).rejects.toThrow();
+    expect(useGoalStore.getState().goals).toHaveLength(1); // unchanged
+  });
+});

--- a/src/zustand/goalStore.ts
+++ b/src/zustand/goalStore.ts
@@ -47,11 +47,21 @@ const serializeDate = (date: Date): string => {
   return `${y}-${m}-${d}`;
 };
 
+// Parse a YYYY-MM-DD (or ISO) date as a *local* date. `new Date("2026-07-31")`
+// is parsed as UTC midnight, which renders as the previous day for users
+// behind UTC — so build the date from its parts instead.
+const parseDate = (value: string): Date => {
+  if (value.includes("T")) return new Date(value);
+  const [y, m, d] = value.split("-").map(Number);
+  if ([y, m, d].every(Number.isFinite)) return new Date(y, m - 1, d);
+  return new Date(value);
+};
+
 const fromApi = (g: ApiGoal): Goal => ({
   id: Number(g.id),
   title: g.title,
   description: g.description ?? null,
-  targetDate: g.targetDate ? new Date(g.targetDate) : null,
+  targetDate: g.targetDate ? parseDate(g.targetDate) : null,
   status: g.status,
   todoIds: g.todoIds ?? [],
   habitIds: g.habitIds ?? [],

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -27,5 +27,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
Adds the project's first **Vitest** setup and a test suite for the goals feature, plus one bug fix surfaced while writing the tests. 26 tests, all green.

## What's covered
**`goalProgress` (pure logic):**
- Empty goals; single `Done` todo = 100%; `TODO`/`In Progress` not counted.
- `Kill` todos excluded from numerator **and** denominator.
- Reminder done/total; habit current-week ratio; multi-habit averaging.
- Equal-weight blending across todos/habits/reminders; a realistic partial case.
- `progressForGoal`: resolves only linked ids; matches habit ids whether **integer (prod)** or **UUID (mock)**; silently drops stale links to deleted items.

**`goalStore`:** API→model mapping, local-date parsing, CRUD state transitions, failure fallback, and the `toBody` partial-update behavior.

## Bug fixed
`fromApi` parsed `targetDate` with `new Date("2026-07-31")`, which is **UTC midnight** — rendering the *previous day* for users behind UTC. Now parsed from date parts as a local date (matching `reminderStore`).

## ⚠️ Edge cases found (documented as tests; not all fixed here)
1. **Goal linked only to `Kill` todos reads as "empty"** → UI shows "No items linked yet" though items are linked. *(test: documents current behavior)*
2. **`Math.round` reports 100% at ≥99.5% actual** → a future auto-complete-at-100% would fire early; recommend gating auto-complete on a true `isComplete`, not the rounded percent. *(test included)*
3. **Tiny progress rounds to 0%** — cosmetic. *(test included)*
4. **`toBody` emits `targetDate: null` on partial updates** → can wipe the deadline on the prod backend; callers must send the full goal for status-only changes (the archive action already does). *(test included)*

## Notes
- Scope is the **frontend** logic (highest-value pure functions). Backend `goalController` (link aggregation/replacement) isn't covered here — it needs a DB-backed harness; recommend as a follow-up.
- Test files are excluded from the production build.
