### PR TITLE
feat: add Profile page (avatar upload, delete account)

### DIFF
--- a/src/componenets/Profile/AvatarUploader.tsx
+++ b/src/componenets/Profile/AvatarUploader.tsx
@@ -1,0 +1,116 @@
+import { useRef, useState } from "react";
+import { Camera, Loader2, Trash2 } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { useUserStore, type CurrentUser } from "@/zustand/userStore";
+
+const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+const initials = (name: string) =>
+  name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("") || "?";
+
+export function AvatarUploader({ user }: { user: CurrentUser }) {
+  const { uploadAvatar, removeAvatar } = useUserStore();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setError("Only PNG, JPEG, WEBP, and GIF images are allowed");
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      setError("Image must be smaller than 5MB");
+      return;
+    }
+
+    setError("");
+    setIsUploading(true);
+    try {
+      await uploadAvatar(file);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to upload avatar");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    setError("");
+    setIsUploading(true);
+    try {
+      await removeAvatar();
+    } catch {
+      setError("Failed to remove avatar");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-4">
+      <div className="relative">
+        <Avatar className="h-20 w-20">
+          {user.avatarUrl && <AvatarImage src={user.avatarUrl} alt={user.name} />}
+          <AvatarFallback className="text-lg">
+            {initials(user.name)}
+          </AvatarFallback>
+        </Avatar>
+        {isUploading && (
+          <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50">
+            <Loader2 className="h-5 w-5 animate-spin text-white" />
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isUploading}
+            className="bg-white/5 border-white/15 text-white hover:bg-white/10"
+            onClick={() => inputRef.current?.click()}
+          >
+            <Camera className="h-4 w-4" />
+            Change photo
+          </Button>
+          {user.avatarUrl && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={isUploading}
+              className="text-white/60 hover:text-red-400"
+              onClick={handleRemove}
+            >
+              <Trash2 className="h-4 w-4" />
+              Remove
+            </Button>
+          )}
+        </div>
+        <p className="text-xs text-white/50">PNG, JPEG, WEBP, or GIF. Max 5MB.</p>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ALLOWED_TYPES.join(",")}
+          className="hidden"
+          onChange={handleFileChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/componenets/Profile/DeleteAccountDialog.tsx
+++ b/src/componenets/Profile/DeleteAccountDialog.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useUserStore } from "@/zustand/userStore";
+import { logout } from "@/lib/authHelpers";
+
+interface DeleteAccountDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeleteAccountDialog({
+  open,
+  onOpenChange,
+}: DeleteAccountDialogProps) {
+  const { deleteAccount } = useUserStore();
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const reset = () => {
+    setPassword("");
+    setError("");
+    setShowPassword(false);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!isDeleting) {
+      if (!next) reset();
+      onOpenChange(next);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!password) {
+      setError("Password is required");
+      return;
+    }
+    setIsDeleting(true);
+    setError("");
+    const result = await deleteAccount(password);
+    setIsDeleting(false);
+    if (!result.ok) {
+      setError(result.error ?? "Failed to delete account");
+      return;
+    }
+    reset();
+    onOpenChange(false);
+    logout();
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This permanently deletes your account and all of your data —
+            todos, habits, reminders, goals, and settings. This can't be
+            undone. Enter your password to confirm.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="delete-account-password">Password</Label>
+          <div className="relative">
+            <Input
+              id="delete-account-password"
+              type={showPassword ? "text" : "password"}
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                if (error) setError("");
+              }}
+              placeholder="Enter your password"
+              aria-invalid={!!error}
+              className={error ? "border-destructive pr-10" : "pr-10"}
+              autoFocus
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="absolute right-0 top-0 h-9 w-9 hover:bg-transparent"
+              onClick={() => setShowPassword((v) => !v)}
+            >
+              {showPassword ? (
+                <EyeOff className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <Eye className="h-4 w-4 text-muted-foreground" />
+              )}
+            </Button>
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={isDeleting}
+            onClick={handleConfirm}
+          >
+            {isDeleting ? "Deleting…" : "Delete account"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/componenets/Sidebar.tsx
+++ b/src/componenets/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Bell,
   Trophy,
   Bot,
+  UserCircle,
   ChevronLeft,
   ChevronRight,
   LogIn,
@@ -158,6 +159,20 @@ export function Sidebar() {
                   <Bot className="h-5 w-5" />
                 </Link>
               </Button>
+
+              {isLoggedIn && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-10 w-10"
+                  title="Profile"
+                  asChild
+                >
+                  <Link to="/profile">
+                    <UserCircle className="h-5 w-5" />
+                  </Link>
+                </Button>
+              )}
             </div>
           ) : (
             // Expanded view - full content
@@ -245,6 +260,20 @@ export function Sidebar() {
                   AI Assistant
                 </Link>
               </Button>
+
+              {isLoggedIn && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start px-0"
+                  asChild
+                >
+                  <Link to="/profile">
+                    <UserCircle className="h-4 w-4 mr-2" />
+                    Profile
+                  </Link>
+                </Button>
+              )}
             </>
           )}
         </nav>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as TodoRouteImport } from './routes/todo'
 import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ReminderRouteImport } from './routes/reminder'
+import { Route as ProfileRouteImport } from './routes/profile'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as HabitTrackerRouteImport } from './routes/habit-tracker'
 import { Route as GoalsRouteImport } from './routes/goals'
@@ -32,6 +33,11 @@ const SignupRoute = SignupRouteImport.update({
 const ReminderRoute = ReminderRouteImport.update({
   id: '/reminder',
   path: '/reminder',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ProfileRoute = ProfileRouteImport.update({
+  id: '/profile',
+  path: '/profile',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -72,6 +78,7 @@ export interface FileRoutesByFullPath {
   '/goals': typeof GoalsRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
+  '/profile': typeof ProfileRoute
   '/reminder': typeof ReminderRoute
   '/signup': typeof SignupRoute
   '/todo': typeof TodoRoute
@@ -83,6 +90,7 @@ export interface FileRoutesByTo {
   '/goals': typeof GoalsRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
+  '/profile': typeof ProfileRoute
   '/reminder': typeof ReminderRoute
   '/signup': typeof SignupRoute
   '/todo': typeof TodoRoute
@@ -95,6 +103,7 @@ export interface FileRoutesById {
   '/goals': typeof GoalsRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
+  '/profile': typeof ProfileRoute
   '/reminder': typeof ReminderRoute
   '/signup': typeof SignupRoute
   '/todo': typeof TodoRoute
@@ -108,6 +117,7 @@ export interface FileRouteTypes {
     | '/goals'
     | '/habit-tracker'
     | '/login'
+    | '/profile'
     | '/reminder'
     | '/signup'
     | '/todo'
@@ -119,6 +129,7 @@ export interface FileRouteTypes {
     | '/goals'
     | '/habit-tracker'
     | '/login'
+    | '/profile'
     | '/reminder'
     | '/signup'
     | '/todo'
@@ -130,6 +141,7 @@ export interface FileRouteTypes {
     | '/goals'
     | '/habit-tracker'
     | '/login'
+    | '/profile'
     | '/reminder'
     | '/signup'
     | '/todo'
@@ -142,6 +154,7 @@ export interface RootRouteChildren {
   GoalsRoute: typeof GoalsRoute
   HabitTrackerRoute: typeof HabitTrackerRoute
   LoginRoute: typeof LoginRoute
+  ProfileRoute: typeof ProfileRoute
   ReminderRoute: typeof ReminderRoute
   SignupRoute: typeof SignupRoute
   TodoRoute: typeof TodoRoute
@@ -168,6 +181,13 @@ declare module '@tanstack/react-router' {
       path: '/reminder'
       fullPath: '/reminder'
       preLoaderRoute: typeof ReminderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/profile': {
+      id: '/profile'
+      path: '/profile'
+      fullPath: '/profile'
+      preLoaderRoute: typeof ProfileRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -222,6 +242,7 @@ const rootRouteChildren: RootRouteChildren = {
   GoalsRoute: GoalsRoute,
   HabitTrackerRoute: HabitTrackerRoute,
   LoginRoute: LoginRoute,
+  ProfileRoute: ProfileRoute,
   ReminderRoute: ReminderRoute,
   SignupRoute: SignupRoute,
   TodoRoute: TodoRoute,

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -1,0 +1,114 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { UserCircle, ShieldAlert } from "lucide-react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { isAuthenticated } from "@/lib/authVerification";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useUserStore } from "@/zustand/userStore";
+import { AvatarUploader } from "@/componenets/Profile/AvatarUploader";
+import { DeleteAccountDialog } from "@/componenets/Profile/DeleteAccountDialog";
+
+export const Route = createFileRoute("/profile")({
+  component: RouteComponent,
+  beforeLoad: async () => {
+    if (!isAuthenticated()) {
+      throw redirect({ to: "/login" });
+    }
+  },
+});
+
+function RouteComponent() {
+  useDocumentTitle("Profile - Zendoro");
+
+  const { user, fetchMe, hasInitialized } = useUserStore();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  useEffect(() => {
+    fetchMe();
+  }, [fetchMe]);
+
+  const isLoading = !hasInitialized;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-2 md:p-4">
+      <header>
+        <h1 className="flex items-center gap-2 text-2xl font-bold text-white md:text-3xl">
+          <UserCircle className="h-6 w-6 text-sky-300" />
+          Profile
+        </h1>
+        <p className="mt-1 text-sm text-white/60">
+          Manage your profile picture and account.
+        </p>
+      </header>
+
+      {isLoading ? (
+        <div className="space-y-6">
+          <Skeleton className="h-32 w-full rounded-xl" />
+          <Skeleton className="h-24 w-full rounded-xl" />
+        </div>
+      ) : !user ? (
+        <p className="text-sm text-white/60">
+          Couldn't load your profile. Try refreshing the page.
+        </p>
+      ) : (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle>Profile picture</CardTitle>
+              <CardDescription>
+                Shown across Zendoro wherever your account appears.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <AvatarUploader user={user} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Account information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <p className="text-xs text-white/50">Name</p>
+                <p className="text-sm font-medium text-white">{user.name}</p>
+              </div>
+              <div>
+                <p className="text-xs text-white/50">Email</p>
+                <p className="text-sm font-medium text-white">{user.email}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="border-destructive/30">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-destructive">
+                <ShieldAlert className="h-4 w-4" />
+                Danger zone
+              </CardTitle>
+              <CardDescription>
+                Permanently delete your account and all of your data. This
+                can't be undone.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                variant="destructive"
+                onClick={() => setDeleteDialogOpen(true)}
+              >
+                Delete account
+              </Button>
+            </CardContent>
+          </Card>
+
+          <DeleteAccountDialog
+            open={deleteDialogOpen}
+            onOpenChange={setDeleteDialogOpen}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/zustand/userStore.ts
+++ b/src/zustand/userStore.ts
@@ -1,0 +1,93 @@
+import { API_BASE_URL } from "@/constants/data";
+import { getAuthToken } from "@/lib/authHelpers";
+import { create } from "zustand";
+
+export type CurrentUser = {
+  id: number;
+  name: string;
+  email: string;
+  avatarUrl: string | null;
+};
+
+const authHeader = (): HeadersInit => ({
+  Authorization: `Bearer ${getAuthToken()}`,
+});
+
+type UserStore = {
+  user: CurrentUser | null;
+  isLoading: boolean;
+  hasInitialized: boolean;
+  fetchMe: () => Promise<void>;
+  uploadAvatar: (file: File) => Promise<void>;
+  removeAvatar: () => Promise<void>;
+  deleteAccount: (password: string) => Promise<{ ok: boolean; error?: string }>;
+  clearUser: () => void;
+};
+
+export const useUserStore = create<UserStore>()((set, get) => ({
+  user: null,
+  isLoading: false,
+  hasInitialized: false,
+
+  fetchMe: async () => {
+    set({ isLoading: true });
+    try {
+      const res = await fetch(`${API_BASE_URL}/user/me`, {
+        method: "GET",
+        headers: authHeader(),
+      });
+      if (!res.ok) throw new Error("Failed to fetch profile");
+      const user: CurrentUser = await res.json();
+      set({ user, isLoading: false, hasInitialized: true });
+    } catch (e) {
+      console.error("Error fetching current user:", e);
+      set({ isLoading: false, hasInitialized: true });
+    }
+  },
+
+  uploadAvatar: async (file) => {
+    const formData = new FormData();
+    formData.append("avatar", file);
+    const res = await fetch(`${API_BASE_URL}/user/avatar`, {
+      method: "POST",
+      headers: authHeader(),
+      body: formData,
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error ?? "Failed to upload avatar");
+    }
+    const { avatarUrl } = await res.json();
+    const current = get().user;
+    if (current) set({ user: { ...current, avatarUrl } });
+  },
+
+  removeAvatar: async () => {
+    const res = await fetch(`${API_BASE_URL}/user/avatar`, {
+      method: "DELETE",
+      headers: authHeader(),
+    });
+    if (!res.ok) throw new Error("Failed to remove avatar");
+    const current = get().user;
+    if (current) set({ user: { ...current, avatarUrl: null } });
+  },
+
+  deleteAccount: async (password) => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/user/me`, {
+        method: "DELETE",
+        headers: { ...authHeader(), "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        return { ok: false, error: err.error ?? "Failed to delete account" };
+      }
+      return { ok: true };
+    } catch {
+      return { ok: false, error: "Failed to delete account" };
+    }
+  },
+
+  clearUser: () => set({ user: null, hasInitialized: false }),
+}));


### PR DESCRIPTION
## Summary
- New `/profile` route: change/remove avatar, view name & email, delete account
- `src/zustand/userStore.ts` — fetch/upload/remove avatar, delete account (mirrors existing store conventions)
- `AvatarUploader` and `DeleteAccountDialog` components under `src/componenets/Profile/`
- Delete account requires typing the current password; wrong password shows an inline error without closing the dialog, correct password deletes the account and logs the user out
- Sidebar gets a "Profile" link (collapsed + expanded), shown only when logged in

