### PR TITLE
feat: add email verification flow to signup and login

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as VerifyEmailRouteImport } from './routes/verify-email'
 import { Route as TodoRouteImport } from './routes/todo'
 import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ReminderRouteImport } from './routes/reminder'
@@ -20,6 +21,11 @@ import { Route as FocusRouteImport } from './routes/focus'
 import { Route as AgentRouteImport } from './routes/agent'
 import { Route as IndexRouteImport } from './routes/index'
 
+const VerifyEmailRoute = VerifyEmailRouteImport.update({
+  id: '/verify-email',
+  path: '/verify-email',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TodoRoute = TodoRouteImport.update({
   id: '/todo',
   path: '/todo',
@@ -82,6 +88,7 @@ export interface FileRoutesByFullPath {
   '/reminder': typeof ReminderRoute
   '/signup': typeof SignupRoute
   '/todo': typeof TodoRoute
+  '/verify-email': typeof VerifyEmailRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -94,6 +101,7 @@ export interface FileRoutesByTo {
   '/reminder': typeof ReminderRoute
   '/signup': typeof SignupRoute
   '/todo': typeof TodoRoute
+  '/verify-email': typeof VerifyEmailRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -107,6 +115,7 @@ export interface FileRoutesById {
   '/reminder': typeof ReminderRoute
   '/signup': typeof SignupRoute
   '/todo': typeof TodoRoute
+  '/verify-email': typeof VerifyEmailRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -121,6 +130,7 @@ export interface FileRouteTypes {
     | '/reminder'
     | '/signup'
     | '/todo'
+    | '/verify-email'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -133,6 +143,7 @@ export interface FileRouteTypes {
     | '/reminder'
     | '/signup'
     | '/todo'
+    | '/verify-email'
   id:
     | '__root__'
     | '/'
@@ -145,6 +156,7 @@ export interface FileRouteTypes {
     | '/reminder'
     | '/signup'
     | '/todo'
+    | '/verify-email'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -158,10 +170,18 @@ export interface RootRouteChildren {
   ReminderRoute: typeof ReminderRoute
   SignupRoute: typeof SignupRoute
   TodoRoute: typeof TodoRoute
+  VerifyEmailRoute: typeof VerifyEmailRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/verify-email': {
+      id: '/verify-email'
+      path: '/verify-email'
+      fullPath: '/verify-email'
+      preLoaderRoute: typeof VerifyEmailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/todo': {
       id: '/todo'
       path: '/todo'
@@ -246,6 +266,7 @@ const rootRouteChildren: RootRouteChildren = {
   ReminderRoute: ReminderRoute,
   SignupRoute: SignupRoute,
   TodoRoute: TodoRoute,
+  VerifyEmailRoute: VerifyEmailRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -96,14 +96,16 @@ function LoginComponent() {
         setErrors({});
         router.navigate({ to: "/" });
       } else {
-        console.log("Login failed with status:", result.status);
-        const errorData = await result.json().catch((e) => {
-          console.log("Failed to parse error response:", e);
-          return {};
-        });
-        console.log("Error data:", errorData);
+        const errorData = await result.json().catch(() => ({}));
+        if (errorData.needsVerification) {
+          router.navigate({
+            to: "/verify-email",
+            search: { email: errorData.email || email },
+          });
+          return;
+        }
         setErrors({
-          general: errorData.message || "Login failed. Please try again.",
+          general: errorData.error || errorData.message || "Login failed. Please try again.",
         });
       }
     } catch {

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -15,7 +15,6 @@ import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { User, Mail, Lock, Eye, EyeOff } from "lucide-react";
 import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { API_BASE_URL } from "@/constants/data";
-import { setAuthToken } from "@/lib/authHelpers";
 import { validateNoInjection } from "@/lib/inputSanitization";
 
 export const Route = createFileRoute("/signup")({
@@ -23,12 +22,7 @@ export const Route = createFileRoute("/signup")({
 });
 type signUpResponseType = {
   message: string;
-  user: {
-    id: number;
-    name: string;
-    email: string;
-  };
-  token: string;
+  email: string;
 };
 function SignupComponent() {
   useDocumentTitle("Sign Up - Zendoro");
@@ -115,15 +109,17 @@ function SignupComponent() {
       });
       if (result.status === 201) {
         const response: signUpResponseType = await result.json();
-        setAuthToken(response.token);
         formRef.current?.reset();
-        router.navigate({ to: "/" });
         setErrors({});
+        router.navigate({
+          to: "/verify-email",
+          search: { email: response.email },
+        });
       } else {
         const errorData = await result.json().catch(() => ({}));
         setErrors({
           general:
-            errorData.message || "Registration failed. Please try again.",
+            errorData.error || errorData.message || "Registration failed. Please try again.",
         });
       }
     } catch {

--- a/src/routes/verify-email.tsx
+++ b/src/routes/verify-email.tsx
@@ -1,0 +1,189 @@
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { MailCheck } from "lucide-react";
+import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
+import { API_BASE_URL } from "@/constants/data";
+import { setAuthToken } from "@/lib/authHelpers";
+
+type VerifyEmailSearch = {
+  email?: string;
+};
+
+export const Route = createFileRoute("/verify-email")({
+  component: VerifyEmailComponent,
+  validateSearch: (search: Record<string, unknown>): VerifyEmailSearch => ({
+    email: typeof search.email === "string" ? search.email : undefined,
+  }),
+});
+
+type verifyResponseType = {
+  message: string;
+  user: { id: number; name: string; email: string };
+  token: string;
+};
+
+function VerifyEmailComponent() {
+  useDocumentTitle("Verify Email - Zendoro");
+  const router = useRouter();
+  const { email } = Route.useSearch();
+
+  const [code, setCode] = useState("");
+  const [error, setError] = useState("");
+  const [resendMessage, setResendMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!email) {
+      setError("Missing email address. Please sign up again.");
+      return;
+    }
+    if (!/^\d{6}$/.test(code)) {
+      setError("Enter the 6-digit code from your email.");
+      return;
+    }
+
+    setError("");
+    setIsLoading(true);
+    try {
+      const result = await fetch(`${API_BASE_URL}/auth/verify-email`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, code }),
+      });
+
+      if (result.ok) {
+        const response: verifyResponseType = await result.json();
+        setAuthToken(response.token);
+        router.navigate({ to: "/" });
+      } else {
+        const errorData = await result.json().catch(() => ({}));
+        setError(errorData.error || "Verification failed. Please try again.");
+      }
+    } catch {
+      setError("Verification failed. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!email) return;
+    setError("");
+    setResendMessage("");
+    setIsResending(true);
+    try {
+      const result = await fetch(`${API_BASE_URL}/auth/resend-verification`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (result.ok) {
+        setResendMessage("A new code has been sent to your email.");
+      } else {
+        const errorData = await result.json().catch(() => ({}));
+        setError(errorData.error || "Failed to resend code. Please try again.");
+      }
+    } catch {
+      setError("Failed to resend code. Please try again.");
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <Card className="border-border/50 shadow-lg">
+          <CardHeader className="text-center space-y-2">
+            <CardTitle className="text-2xl font-beba">
+              Verify Your Email
+            </CardTitle>
+            <CardDescription>
+              {email
+                ? `Enter the 6-digit code we sent to ${email}`
+                : "Enter the 6-digit code we sent to your email"}
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {error && (
+                <div className="p-3 text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md">
+                  {error}
+                </div>
+              )}
+              {resendMessage && (
+                <div className="p-3 text-sm text-sky-300 bg-sky-500/10 border border-sky-500/20 rounded-md">
+                  {resendMessage}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="code">
+                  <MailCheck className="h-4 w-4" />
+                  Verification Code
+                </Label>
+                <Input
+                  id="code"
+                  name="code"
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={6}
+                  placeholder="123456"
+                  value={code}
+                  onChange={(e) =>
+                    setCode(e.target.value.replace(/\D/g, "").slice(0, 6))
+                  }
+                  className="tracking-[0.5em] text-center text-lg"
+                />
+              </div>
+
+              <GradientButton
+                type="submit"
+                className="w-full"
+                disabled={isLoading}
+              >
+                {isLoading ? "Verifying..." : "Verify Email"}
+              </GradientButton>
+            </form>
+          </CardContent>
+
+          <CardFooter className="flex flex-col space-y-4 pt-0">
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full"
+              onClick={handleResend}
+              disabled={isResending || !email}
+            >
+              {isResending ? "Sending..." : "Resend code"}
+            </Button>
+            <div className="text-center text-sm text-white/60">
+              Wrong email?{" "}
+              <Link
+                to="/signup"
+                className="font-medium text-white hover:underline"
+              >
+                Sign up again
+              </Link>
+            </div>
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Signup now requests a 6-digit verification code from the backend instead of logging the user in immediately, and routes to a new `/verify-email` screen
- Login rejects unverified accounts (`needsVerification` response) and redirects to `/verify-email` with the email pre-filled
- Added "resend code" action on the verify screen
- Fixed a pre-existing bug where login/signup error messages read `errorData.message`, but the backend actually returns `errorData.error` — failed requests were always showing the generic fallback text
