### PR TITLE
feat: add email reminder lead-time option to reminders

### DIFF
--- a/src/componenets/Reminder/ReminderCard.tsx
+++ b/src/componenets/Reminder/ReminderCard.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
-import { Edit, Trash2, Clock, AlertCircle } from "lucide-react";
+import { Edit, Trash2, Clock, AlertCircle, Mail } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Reminder } from "@/zustand/reminderStore";
 
@@ -130,6 +130,9 @@ export function ReminderCard({
             <div className="flex items-center gap-1 text-xs text-white/60">
               <Clock className="w-3 h-3" />
               <span>{reminder.time}</span>
+              {reminder.remindBeforeMinutes != null && (
+                <Mail className="w-3 h-3 ml-1" />
+              )}
             </div>
 
             <div className="flex items-center gap-1">

--- a/src/componenets/Reminder/ReminderForm.tsx
+++ b/src/componenets/Reminder/ReminderForm.tsx
@@ -23,13 +23,20 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
-import { CalendarIcon, Clock } from "lucide-react";
+import { CalendarIcon, Clock, Mail } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import type { Reminder } from "@/zustand/reminderStore";
 import { GradientButton } from "../customUIComponenets/CustomButton";
-import { REMINDER_PRIORITY_COLORS } from "@/constants/data";
+import { REMINDER_PRIORITY_COLORS, REMINDER_LEAD_TIME_OPTIONS } from "@/constants/data";
 import { containsDangerousInput } from "@/lib/inputSanitization";
+
+// Select can't hold a null value, so "none" stands in for "no email reminder"
+const NO_EMAIL_REMINDER = "none";
+const leadTimeToSelectValue = (v: number | null | undefined) =>
+  v == null ? NO_EMAIL_REMINDER : String(v);
+const selectValueToLeadTime = (v: string): number | null =>
+  v === NO_EMAIL_REMINDER ? null : Number(v);
 
 interface ReminderFormProps {
   reminder?: Reminder | null;
@@ -52,6 +59,7 @@ export function ReminderForm({
     date: selectedDate || new Date(),
     time: "09:00",
     priority: "medium" as Reminder["priority"],
+    remindBeforeMinutes: null as number | null,
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -64,6 +72,7 @@ export function ReminderForm({
         date: reminder.date,
         time: reminder.time,
         priority: reminder.priority,
+        remindBeforeMinutes: reminder.remindBeforeMinutes ?? null,
       });
     } else if (selectedDate) {
       // Reset form but keep the selected date when adding a new reminder
@@ -73,6 +82,7 @@ export function ReminderForm({
         date: selectedDate,
         time: "09:00",
         priority: "medium",
+        remindBeforeMinutes: null,
       });
     }
   }, [reminder, selectedDate, defaultTitle]);
@@ -116,6 +126,7 @@ export function ReminderForm({
       time: formData.time,
       priority: formData.priority,
       completed: reminder?.completed || false,
+      remindBeforeMinutes: formData.remindBeforeMinutes,
     };
 
     onSave(reminderData);
@@ -316,6 +327,38 @@ export function ReminderForm({
                     </span>
                   </div>
                 </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Email reminder */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Email reminder</Label>
+            <Select
+              value={leadTimeToSelectValue(formData.remindBeforeMinutes)}
+              onValueChange={(value) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  remindBeforeMinutes: selectValueToLeadTime(value),
+                }))
+              }
+            >
+              <SelectTrigger>
+                <div className="flex items-center">
+                  <Mail className="mr-2 h-4 w-4" />
+                  <SelectValue />
+                </div>
+              </SelectTrigger>
+              <SelectContent className="text-white">
+                {REMINDER_LEAD_TIME_OPTIONS.map((option) => (
+                  <SelectItem
+                    key={leadTimeToSelectValue(option.value)}
+                    value={leadTimeToSelectValue(option.value)}
+                    className="text-white focus:text-white"
+                  >
+                    {option.label}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -22,6 +22,21 @@ export const REMINDER_PRIORITY_COLORS = {
   high: "bg-red-400",
 };
 
+export const REMINDER_LEAD_TIME_OPTIONS: {
+  value: number | null;
+  label: string;
+}[] = [
+  { value: null, label: "No email reminder" },
+  { value: 0, label: "At time of reminder" },
+  { value: 5, label: "5 minutes before" },
+  { value: 15, label: "15 minutes before" },
+  { value: 30, label: "30 minutes before" },
+  { value: 60, label: "1 hour before" },
+  { value: 120, label: "2 hours before" },
+  { value: 1440, label: "1 day before" },
+  { value: 2880, label: "2 days before" },
+];
+
 export const API_BASE_URL =
   import.meta.env.VITE_API_URL ?? "https://zendoro-backend.onrender.com";
 export const LS_ZENDORO_AUTH = "zendoro-auth-token";

--- a/src/zustand/reminderStore.ts
+++ b/src/zustand/reminderStore.ts
@@ -13,6 +13,7 @@ export interface Reminder {
   completed: boolean;
   todoId?: number | null;
   userId?: number;
+  remindBeforeMinutes?: number | null;
 }
 
 type ApiReminder = {
@@ -25,6 +26,7 @@ type ApiReminder = {
   completed: boolean;
   todoId?: number | null;
   userId?: number;
+  remindBeforeMinutes?: number | null;
 };
 
 // Helpers to avoid timezone-related off-by-one date issues
@@ -111,6 +113,7 @@ export const useReminderStore = create<ReminderStore>()((set, get) => ({
         completed: r.completed,
         todoId: r.todoId ?? null,
         userId: r.userId,
+        remindBeforeMinutes: r.remindBeforeMinutes ?? null,
       }));
       set({ reminders, isLoading: false, hasInitialized: true });
     } catch (e) {
@@ -146,6 +149,7 @@ export const useReminderStore = create<ReminderStore>()((set, get) => ({
         completed: data.completed,
         todoId: data.todoId ?? null,
         userId: data.userId,
+        remindBeforeMinutes: data.remindBeforeMinutes ?? null,
       };
       set((state) => ({
         reminders: [...state.reminders, created],
@@ -184,6 +188,7 @@ export const useReminderStore = create<ReminderStore>()((set, get) => ({
         completed: data.completed,
         todoId: data.todoId ?? null,
         userId: data.userId,
+        remindBeforeMinutes: data.remindBeforeMinutes ?? null,
       };
       set((state) => ({
         reminders: state.reminders.map((r) => (r.id === id ? updated : r)),


### PR DESCRIPTION
## Summary
- New "Email reminder" Select in the reminder form (next to Priority) with options: no reminder, at time of reminder, 5/15/30 min before, 1/2 hours before, 1/2 days before
- `remindBeforeMinutes` threaded through `Reminder`/`ApiReminder` types and all three CRUD response mappings in `reminderStore.ts`
- Small mail icon on the reminder card when a lead time is set
