### PR TITLE
feat: add forgot/reset password flow

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,11 +12,13 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as VerifyEmailRouteImport } from './routes/verify-email'
 import { Route as TodoRouteImport } from './routes/todo'
 import { Route as SignupRouteImport } from './routes/signup'
+import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as ReminderRouteImport } from './routes/reminder'
 import { Route as ProfileRouteImport } from './routes/profile'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as HabitTrackerRouteImport } from './routes/habit-tracker'
 import { Route as GoalsRouteImport } from './routes/goals'
+import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as FocusRouteImport } from './routes/focus'
 import { Route as AgentRouteImport } from './routes/agent'
 import { Route as IndexRouteImport } from './routes/index'
@@ -34,6 +36,11 @@ const TodoRoute = TodoRouteImport.update({
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ResetPasswordRoute = ResetPasswordRouteImport.update({
+  id: '/reset-password',
+  path: '/reset-password',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ReminderRoute = ReminderRouteImport.update({
@@ -61,6 +68,11 @@ const GoalsRoute = GoalsRouteImport.update({
   path: '/goals',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
+  id: '/forgot-password',
+  path: '/forgot-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const FocusRoute = FocusRouteImport.update({
   id: '/focus',
   path: '/focus',
@@ -81,11 +93,13 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/agent': typeof AgentRoute
   '/focus': typeof FocusRoute
+  '/forgot-password': typeof ForgotPasswordRoute
   '/goals': typeof GoalsRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
   '/profile': typeof ProfileRoute
   '/reminder': typeof ReminderRoute
+  '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
   '/todo': typeof TodoRoute
   '/verify-email': typeof VerifyEmailRoute
@@ -94,11 +108,13 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/agent': typeof AgentRoute
   '/focus': typeof FocusRoute
+  '/forgot-password': typeof ForgotPasswordRoute
   '/goals': typeof GoalsRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
   '/profile': typeof ProfileRoute
   '/reminder': typeof ReminderRoute
+  '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
   '/todo': typeof TodoRoute
   '/verify-email': typeof VerifyEmailRoute
@@ -108,11 +124,13 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/agent': typeof AgentRoute
   '/focus': typeof FocusRoute
+  '/forgot-password': typeof ForgotPasswordRoute
   '/goals': typeof GoalsRoute
   '/habit-tracker': typeof HabitTrackerRoute
   '/login': typeof LoginRoute
   '/profile': typeof ProfileRoute
   '/reminder': typeof ReminderRoute
+  '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
   '/todo': typeof TodoRoute
   '/verify-email': typeof VerifyEmailRoute
@@ -123,11 +141,13 @@ export interface FileRouteTypes {
     | '/'
     | '/agent'
     | '/focus'
+    | '/forgot-password'
     | '/goals'
     | '/habit-tracker'
     | '/login'
     | '/profile'
     | '/reminder'
+    | '/reset-password'
     | '/signup'
     | '/todo'
     | '/verify-email'
@@ -136,11 +156,13 @@ export interface FileRouteTypes {
     | '/'
     | '/agent'
     | '/focus'
+    | '/forgot-password'
     | '/goals'
     | '/habit-tracker'
     | '/login'
     | '/profile'
     | '/reminder'
+    | '/reset-password'
     | '/signup'
     | '/todo'
     | '/verify-email'
@@ -149,11 +171,13 @@ export interface FileRouteTypes {
     | '/'
     | '/agent'
     | '/focus'
+    | '/forgot-password'
     | '/goals'
     | '/habit-tracker'
     | '/login'
     | '/profile'
     | '/reminder'
+    | '/reset-password'
     | '/signup'
     | '/todo'
     | '/verify-email'
@@ -163,11 +187,13 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AgentRoute: typeof AgentRoute
   FocusRoute: typeof FocusRoute
+  ForgotPasswordRoute: typeof ForgotPasswordRoute
   GoalsRoute: typeof GoalsRoute
   HabitTrackerRoute: typeof HabitTrackerRoute
   LoginRoute: typeof LoginRoute
   ProfileRoute: typeof ProfileRoute
   ReminderRoute: typeof ReminderRoute
+  ResetPasswordRoute: typeof ResetPasswordRoute
   SignupRoute: typeof SignupRoute
   TodoRoute: typeof TodoRoute
   VerifyEmailRoute: typeof VerifyEmailRoute
@@ -194,6 +220,13 @@ declare module '@tanstack/react-router' {
       path: '/signup'
       fullPath: '/signup'
       preLoaderRoute: typeof SignupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/reset-password': {
+      id: '/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof ResetPasswordRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/reminder': {
@@ -231,6 +264,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GoalsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/forgot-password': {
+      id: '/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof ForgotPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/focus': {
       id: '/focus'
       path: '/focus'
@@ -259,11 +299,13 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AgentRoute: AgentRoute,
   FocusRoute: FocusRoute,
+  ForgotPasswordRoute: ForgotPasswordRoute,
   GoalsRoute: GoalsRoute,
   HabitTrackerRoute: HabitTrackerRoute,
   LoginRoute: LoginRoute,
   ProfileRoute: ProfileRoute,
   ReminderRoute: ReminderRoute,
+  ResetPasswordRoute: ResetPasswordRoute,
   SignupRoute: SignupRoute,
   TodoRoute: TodoRoute,
   VerifyEmailRoute: VerifyEmailRoute,

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -10,32 +10,21 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
-import { Mail, Lock, Eye, EyeOff } from "lucide-react";
+import { Mail } from "lucide-react";
 import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { API_BASE_URL } from "@/constants/data";
-import { setAuthToken } from "@/lib/authHelpers";
 import { validateNoInjection } from "@/lib/inputSanitization";
 
-export const Route = createFileRoute("/login")({
-  component: LoginComponent,
+export const Route = createFileRoute("/forgot-password")({
+  component: ForgotPasswordComponent,
 });
-type logInResponseType = {
-  message: string;
-  user: {
-    id: number;
-    name: string;
-    email: string;
-  };
-  token: string;
-};
-function LoginComponent() {
-  useDocumentTitle("Login - Zendoro");
+
+function ForgotPasswordComponent() {
+  useDocumentTitle("Forgot Password - Zendoro");
   const router = useRouter();
 
   const formRef = useRef<HTMLFormElement>(null);
-  const [showPassword, setShowPassword] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
 
@@ -43,7 +32,6 @@ function LoginComponent() {
     const newErrors: Record<string, string> = {};
 
     const email = formData.get("email") as string;
-    const password = formData.get("password") as string;
 
     if (!email?.trim()) {
       newErrors.email = "Email is required";
@@ -51,13 +39,7 @@ function LoginComponent() {
       newErrors.email = "Please enter a valid email address";
     }
 
-    if (!password?.trim()) {
-      newErrors.password = "Password is required";
-    } else if (password.length < 6) {
-      newErrors.password = "Password must be at least 6 characters";
-    }
-
-    const injectionErrors = validateNoInjection({ email, password });
+    const injectionErrors = validateNoInjection({ email });
     Object.assign(newErrors, injectionErrors);
 
     setErrors(newErrors);
@@ -77,39 +59,24 @@ function LoginComponent() {
     setIsLoading(true);
     try {
       const email = formData.get("email") as string;
-      const password = formData.get("password") as string;
-      const result = await fetch(`${API_BASE_URL}/auth/login`, {
+      const result = await fetch(`${API_BASE_URL}/auth/forgot-password`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          email,
-          password,
-        }),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
       });
 
-      if (result.ok || result.status === 200) {
-        const response: logInResponseType = await result.json();
-        setAuthToken(response.token);
+      if (result.ok) {
         formRef.current?.reset();
         setErrors({});
-        router.navigate({ to: "/" });
+        router.navigate({ to: "/reset-password", search: { email } });
       } else {
         const errorData = await result.json().catch(() => ({}));
-        if (errorData.needsVerification) {
-          router.navigate({
-            to: "/verify-email",
-            search: { email: errorData.email || email },
-          });
-          return;
-        }
         setErrors({
-          general: errorData.error || errorData.message || "Login failed. Please try again.",
+          general: errorData.error || "Failed to send reset code. Please try again.",
         });
       }
     } catch {
-      setErrors({ general: "Login failed. Please try again." });
+      setErrors({ general: "Failed to send reset code. Please try again." });
     } finally {
       setIsLoading(false);
     }
@@ -120,10 +87,9 @@ function LoginComponent() {
       <div className="w-full max-w-md">
         <Card className="border-border/50 shadow-lg">
           <CardHeader className="text-center space-y-2">
-            <CardTitle className="text-2xl font-beba">Welcome Back</CardTitle>
+            <CardTitle className="text-2xl font-beba">Forgot Password</CardTitle>
             <CardDescription>
-              Sign in to your Zendoro account to continue your productivity
-              journey
+              Enter your email and we'll send you a code to reset your password
             </CardDescription>
           </CardHeader>
 
@@ -153,49 +119,6 @@ function LoginComponent() {
                 )}
               </div>
 
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="password">
-                    <Lock className="h-4 w-4" />
-                    Password
-                  </Label>
-                  <Link
-                    to="/forgot-password"
-                    className="text-xs font-medium text-white/60 hover:text-white hover:underline"
-                  >
-                    Forgot password?
-                  </Link>
-                </div>
-                <div className="relative">
-                  <Input
-                    id="password"
-                    name="password"
-                    type={showPassword ? "text" : "password"}
-                    placeholder="Enter your password"
-                    aria-invalid={!!errors.password}
-                    className={
-                      errors.password ? "border-destructive pr-10" : "pr-10"
-                    }
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="absolute right-0 top-0 h-9 w-9 hover:bg-transparent"
-                    onClick={() => setShowPassword(!showPassword)}
-                  >
-                    {showPassword ? (
-                      <EyeOff className="h-4 w-4 text-muted-foreground" />
-                    ) : (
-                      <Eye className="h-4 w-4 text-muted-foreground" />
-                    )}
-                  </Button>
-                </div>
-                {errors.password && (
-                  <p className="text-sm text-destructive">{errors.password}</p>
-                )}
-              </div>
-
               {/* Honeypot — hidden from real users, bots fill it and get silently rejected */}
               <div
                 aria-hidden="true"
@@ -216,19 +139,19 @@ function LoginComponent() {
                 className="w-full"
                 disabled={isLoading}
               >
-                {isLoading ? "Signing in..." : "Sign In"}
+                {isLoading ? "Sending..." : "Send Reset Code"}
               </GradientButton>
             </form>
           </CardContent>
 
           <CardFooter className="flex flex-col space-y-4 pt-0">
             <div className="text-center text-sm text-white/60">
-              Don't have an account?{" "}
+              Remembered your password?{" "}
               <Link
-                to="/signup"
+                to="/login"
                 className="font-medium text-white hover:underline"
               >
-                Sign up here
+                Sign in here
               </Link>
             </div>
           </CardFooter>

--- a/src/routes/reset-password.tsx
+++ b/src/routes/reset-password.tsx
@@ -1,0 +1,302 @@
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { MailCheck, Lock, Eye, EyeOff } from "lucide-react";
+import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
+import { API_BASE_URL } from "@/constants/data";
+import { setAuthToken } from "@/lib/authHelpers";
+
+type ResetPasswordSearch = {
+  email?: string;
+};
+
+export const Route = createFileRoute("/reset-password")({
+  component: ResetPasswordComponent,
+  validateSearch: (search: Record<string, unknown>): ResetPasswordSearch => ({
+    email: typeof search.email === "string" ? search.email : undefined,
+  }),
+});
+
+type resetResponseType = {
+  message: string;
+  user: { id: number; name: string; email: string };
+  token: string;
+};
+
+function ResetPasswordComponent() {
+  useDocumentTitle("Reset Password - Zendoro");
+  const router = useRouter();
+  const { email } = Route.useSearch();
+
+  const [code, setCode] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [resendMessage, setResendMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+
+  const validateForm = () => {
+    const newErrors: Record<string, string> = {};
+
+    if (!email) {
+      newErrors.general = "Missing email address. Please start over.";
+    }
+    if (!/^\d{6}$/.test(code)) {
+      newErrors.code = "Enter the 6-digit code from your email.";
+    }
+    if (!newPassword) {
+      newErrors.newPassword = "Password is required";
+    } else if (
+      !newPassword.match(
+        "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[-+_!@#$%^&*.,?]).{8,}$",
+      )
+    ) {
+      newErrors.newPassword =
+        "Password must be at least 8 characters and include uppercase, lowercase, number, and special character";
+    }
+    if (!confirmPassword) {
+      newErrors.confirmPassword = "Please confirm your password";
+    } else if (newPassword !== confirmPassword) {
+      newErrors.confirmPassword = "Passwords do not match";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!validateForm()) return;
+
+    setErrors({});
+    setIsLoading(true);
+    try {
+      const result = await fetch(`${API_BASE_URL}/auth/reset-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, code, newPassword }),
+      });
+
+      if (result.ok) {
+        const response: resetResponseType = await result.json();
+        setAuthToken(response.token);
+        router.navigate({ to: "/" });
+      } else {
+        const errorData = await result.json().catch(() => ({}));
+        setErrors({
+          general: errorData.error || "Password reset failed. Please try again.",
+        });
+      }
+    } catch {
+      setErrors({ general: "Password reset failed. Please try again." });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!email) return;
+    setErrors({});
+    setResendMessage("");
+    setIsResending(true);
+    try {
+      const result = await fetch(`${API_BASE_URL}/auth/forgot-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (result.ok) {
+        setResendMessage("A new code has been sent to your email.");
+      } else {
+        const errorData = await result.json().catch(() => ({}));
+        setErrors({
+          general: errorData.error || "Failed to resend code. Please try again.",
+        });
+      }
+    } catch {
+      setErrors({ general: "Failed to resend code. Please try again." });
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <Card className="border-border/50 shadow-lg">
+          <CardHeader className="text-center space-y-2">
+            <CardTitle className="text-2xl font-beba">Reset Password</CardTitle>
+            <CardDescription>
+              {email
+                ? `Enter the code we sent to ${email} and choose a new password`
+                : "Enter the code we sent to your email and choose a new password"}
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {errors.general && (
+                <div className="p-3 text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md">
+                  {errors.general}
+                </div>
+              )}
+              {resendMessage && (
+                <div className="p-3 text-sm text-sky-300 bg-sky-500/10 border border-sky-500/20 rounded-md">
+                  {resendMessage}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="code">
+                  <MailCheck className="h-4 w-4" />
+                  Reset Code
+                </Label>
+                <Input
+                  id="code"
+                  name="code"
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={6}
+                  placeholder="123456"
+                  value={code}
+                  onChange={(e) =>
+                    setCode(e.target.value.replace(/\D/g, "").slice(0, 6))
+                  }
+                  aria-invalid={!!errors.code}
+                  className={
+                    (errors.code ? "border-destructive " : "") +
+                    "tracking-[0.5em] text-center text-lg"
+                  }
+                />
+                {errors.code && (
+                  <p className="text-sm text-destructive">{errors.code}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="newPassword">
+                  <Lock className="h-4 w-4" />
+                  New Password
+                </Label>
+                <div className="relative">
+                  <Input
+                    id="newPassword"
+                    name="newPassword"
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Create a new password"
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    aria-invalid={!!errors.newPassword}
+                    className={
+                      errors.newPassword ? "border-destructive pr-10" : "pr-10"
+                    }
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="absolute right-0 top-0 h-9 w-9 hover:bg-transparent"
+                    onClick={() => setShowPassword(!showPassword)}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <Eye className="h-4 w-4 text-muted-foreground" />
+                    )}
+                  </Button>
+                </div>
+                {errors.newPassword && (
+                  <p className="text-sm text-destructive">{errors.newPassword}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword">
+                  <Lock className="h-4 w-4" />
+                  Confirm Password
+                </Label>
+                <div className="relative">
+                  <Input
+                    id="confirmPassword"
+                    name="confirmPassword"
+                    type={showConfirmPassword ? "text" : "password"}
+                    placeholder="Confirm your new password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    aria-invalid={!!errors.confirmPassword}
+                    className={
+                      errors.confirmPassword
+                        ? "border-destructive pr-10"
+                        : "pr-10"
+                    }
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="absolute right-0 top-0 h-9 w-9 hover:bg-transparent"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <Eye className="h-4 w-4 text-muted-foreground" />
+                    )}
+                  </Button>
+                </div>
+                {errors.confirmPassword && (
+                  <p className="text-sm text-destructive">
+                    {errors.confirmPassword}
+                  </p>
+                )}
+              </div>
+
+              <GradientButton
+                type="submit"
+                className="w-full"
+                disabled={isLoading}
+              >
+                {isLoading ? "Resetting..." : "Reset Password"}
+              </GradientButton>
+            </form>
+          </CardContent>
+
+          <CardFooter className="flex flex-col space-y-4 pt-0">
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full"
+              onClick={handleResend}
+              disabled={isResending || !email}
+            >
+              {isResending ? "Sending..." : "Resend code"}
+            </Button>
+            <div className="text-center text-sm text-white/60">
+              Wrong email?{" "}
+              <Link
+                to="/forgot-password"
+                className="font-medium text-white hover:underline"
+              >
+                Start over
+              </Link>
+            </div>
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/forgot-password` route: email field, submits to `POST /auth/forgot-password`, redirects to `/reset-password?email=...`
- New `/reset-password` route: modeled on `verify-email.tsx` — 6-digit code + new password + confirm password (same complexity validation as signup), a "Resend code" action, submits to `POST /auth/reset-password`, auto-logs in on success
- Added a "Forgot password?" link on the login page next to the Password label

