### PR TITLE
test: add unit tests for auth validation logic

### DIFF
--- a/src/lib/authValidation.test.ts
+++ b/src/lib/authValidation.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidEmail,
+  isValidLoginPassword,
+  isStrongPassword,
+  isValidSixDigitCode,
+} from "./authValidation";
+
+describe("isValidEmail", () => {
+  it("accepts a normal email", () => {
+    expect(isValidEmail("user@example.com")).toBe(true);
+  });
+
+  it("accepts a plus-addressed email", () => {
+    expect(isValidEmail("user+test@example.com")).toBe(true);
+  });
+
+  it.each(["", "not-an-email", "user@", "@example.com", "user example.com"])(
+    "rejects %j",
+    (value) => {
+      expect(isValidEmail(value)).toBe(false);
+    },
+  );
+});
+
+describe("isValidLoginPassword", () => {
+  it("accepts a 6+ character password", () => {
+    expect(isValidLoginPassword("abcdef")).toBe(true);
+  });
+
+  it("rejects fewer than 6 characters", () => {
+    expect(isValidLoginPassword("abcde")).toBe(false);
+  });
+
+  it("does not require complexity (unlike signup/reset)", () => {
+    expect(isValidLoginPassword("allsimple")).toBe(true);
+  });
+});
+
+describe("isStrongPassword", () => {
+  it("accepts a password with upper, lower, digit, and special char at 8+ length", () => {
+    expect(isStrongPassword("Abcdef1!")).toBe(true);
+  });
+
+  it("rejects fewer than 8 characters even if otherwise complex", () => {
+    expect(isStrongPassword("Ab1!")).toBe(false);
+  });
+
+  it("rejects a password missing an uppercase letter", () => {
+    expect(isStrongPassword("abcdef1!")).toBe(false);
+  });
+
+  it("rejects a password missing a lowercase letter", () => {
+    expect(isStrongPassword("ABCDEF1!")).toBe(false);
+  });
+
+  it("rejects a password missing a digit", () => {
+    expect(isStrongPassword("Abcdefg!")).toBe(false);
+  });
+
+  it("rejects a password missing a special character", () => {
+    expect(isStrongPassword("Abcdefg1")).toBe(false);
+  });
+
+  it("rejects an empty password", () => {
+    expect(isStrongPassword("")).toBe(false);
+  });
+});
+
+describe("isValidSixDigitCode", () => {
+  it("accepts exactly 6 digits", () => {
+    expect(isValidSixDigitCode("123456")).toBe(true);
+  });
+
+  it("rejects fewer than 6 digits", () => {
+    expect(isValidSixDigitCode("12345")).toBe(false);
+  });
+
+  it("rejects more than 6 digits", () => {
+    expect(isValidSixDigitCode("1234567")).toBe(false);
+  });
+
+  it("rejects non-digit characters", () => {
+    expect(isValidSixDigitCode("12345a")).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isValidSixDigitCode("")).toBe(false);
+  });
+});

--- a/src/lib/authValidation.ts
+++ b/src/lib/authValidation.ts
@@ -1,0 +1,18 @@
+export function isValidEmail(email: string): boolean {
+  return /\S+@\S+\.\S+/.test(email);
+}
+
+// Login only gates on length — signup/reset require full complexity below.
+export function isValidLoginPassword(password: string): boolean {
+  return password.length >= 6;
+}
+
+export function isStrongPassword(password: string): boolean {
+  return /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[-+_!@#$%^&*.,?]).{8,}$/.test(
+    password,
+  );
+}
+
+export function isValidSixDigitCode(code: string): boolean {
+  return /^\d{6}$/.test(code);
+}

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -15,6 +15,7 @@ import { Mail } from "lucide-react";
 import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { API_BASE_URL } from "@/constants/data";
 import { validateNoInjection } from "@/lib/inputSanitization";
+import { isValidEmail } from "@/lib/authValidation";
 
 export const Route = createFileRoute("/forgot-password")({
   component: ForgotPasswordComponent,
@@ -35,7 +36,7 @@ function ForgotPasswordComponent() {
 
     if (!email?.trim()) {
       newErrors.email = "Email is required";
-    } else if (!/\S+@\S+\.\S+/.test(email)) {
+    } else if (!isValidEmail(email)) {
       newErrors.email = "Please enter a valid email address";
     }
 

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -17,6 +17,7 @@ import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { API_BASE_URL } from "@/constants/data";
 import { setAuthToken } from "@/lib/authHelpers";
 import { validateNoInjection } from "@/lib/inputSanitization";
+import { isValidEmail, isValidLoginPassword } from "@/lib/authValidation";
 
 export const Route = createFileRoute("/login")({
   component: LoginComponent,
@@ -47,13 +48,13 @@ function LoginComponent() {
 
     if (!email?.trim()) {
       newErrors.email = "Email is required";
-    } else if (!/\S+@\S+\.\S+/.test(email)) {
+    } else if (!isValidEmail(email)) {
       newErrors.email = "Please enter a valid email address";
     }
 
     if (!password?.trim()) {
       newErrors.password = "Password is required";
-    } else if (password.length < 6) {
+    } else if (!isValidLoginPassword(password)) {
       newErrors.password = "Password must be at least 6 characters";
     }
 

--- a/src/routes/reset-password.tsx
+++ b/src/routes/reset-password.tsx
@@ -16,6 +16,7 @@ import { MailCheck, Lock, Eye, EyeOff } from "lucide-react";
 import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { API_BASE_URL } from "@/constants/data";
 import { setAuthToken } from "@/lib/authHelpers";
+import { isValidSixDigitCode, isStrongPassword } from "@/lib/authValidation";
 
 type ResetPasswordSearch = {
   email?: string;
@@ -55,16 +56,12 @@ function ResetPasswordComponent() {
     if (!email) {
       newErrors.general = "Missing email address. Please start over.";
     }
-    if (!/^\d{6}$/.test(code)) {
+    if (!isValidSixDigitCode(code)) {
       newErrors.code = "Enter the 6-digit code from your email.";
     }
     if (!newPassword) {
       newErrors.newPassword = "Password is required";
-    } else if (
-      !newPassword.match(
-        "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[-+_!@#$%^&*.,?]).{8,}$",
-      )
-    ) {
+    } else if (!isStrongPassword(newPassword)) {
       newErrors.newPassword =
         "Password must be at least 8 characters and include uppercase, lowercase, number, and special character";
     }

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -16,6 +16,7 @@ import { User, Mail, Lock, Eye, EyeOff } from "lucide-react";
 import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { API_BASE_URL } from "@/constants/data";
 import { validateNoInjection } from "@/lib/inputSanitization";
+import { isValidEmail, isStrongPassword } from "@/lib/authValidation";
 
 export const Route = createFileRoute("/signup")({
   component: SignupComponent,
@@ -50,22 +51,15 @@ function SignupComponent() {
 
     if (!email?.trim()) {
       newErrors.email = "Email is required";
-    } else if (!/\S+@\S+\.\S+/.test(email)) {
+    } else if (!isValidEmail(email)) {
       newErrors.email = "Please enter a valid email address";
     }
 
     if (!password?.trim()) {
       newErrors.password = "Password is required";
-    } else if (password.length < 8) {
-      newErrors.password = "Password must be at least 6 characters";
-    }
-    if (
-      !password.match(
-        "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[-+_!@#$%^&*.,?]).+$",
-      )
-    ) {
+    } else if (!isStrongPassword(password)) {
       newErrors.password =
-        "Password must include uppercase, lowercase, number, and special character";
+        "Password must be at least 8 characters and include uppercase, lowercase, number, and special character";
     }
     if (!confirmPassword?.trim()) {
       newErrors.confirmPassword = "Please confirm your password";

--- a/src/routes/verify-email.tsx
+++ b/src/routes/verify-email.tsx
@@ -16,6 +16,7 @@ import { MailCheck } from "lucide-react";
 import { GradientButton } from "@/componenets/customUIComponenets/CustomButton";
 import { API_BASE_URL } from "@/constants/data";
 import { setAuthToken } from "@/lib/authHelpers";
+import { isValidSixDigitCode } from "@/lib/authValidation";
 
 type VerifyEmailSearch = {
   email?: string;
@@ -51,7 +52,7 @@ function VerifyEmailComponent() {
       setError("Missing email address. Please sign up again.");
       return;
     }
-    if (!/^\d{6}$/.test(code)) {
+    if (!isValidSixDigitCode(code)) {
       setError("Enter the 6-digit code from your email.");
       return;
     }


### PR DESCRIPTION
## Summary
- New `src/lib/authValidation.ts` extracting the email/password/code regex checks that were duplicated inline across `login.tsx`, `signup.tsx`, `verify-email.tsx`, `forgot-password.tsx`, and `reset-password.tsx`
- 22 unit tests in `authValidation.test.ts`, matching the existing lightweight test style in this repo (pure logic, `environment: "node"`, no component rendering / no new test dependencies)
- All five route files now call the shared functions instead of duplicating regexes

## Incidental fixes (surfaced by the extraction, not separately introduced)
- `signup.tsx`: the password-complexity check ran unconditionally after the length check, so an *empty* password showed "must include uppercase, lowercase..." instead of "Password is required". Extracting into one `isStrongPassword` predicate naturally fixes the ordering.
- `signup.tsx`: the length-error message said "must be at least 6 characters" while the code actually required 8 — corrected the copy.

## Test plan
- [x] `npx tsc -b` passes
- [x] `npx vitest run` passes (48/48 — 22 new + 26 existing)
- [x] Manually verified in the browser: an 8+ char password without complexity shows one accurate error; a valid strong password clears it and submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)