### PR TITLE
feat: add admin panel

### DIFF
--- a/src/componenets/Admin/AddUserDialog.tsx
+++ b/src/componenets/Admin/AddUserDialog.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { UserPlus } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useAdminStore } from "@/zustand/adminStore";
+import { isValidEmail, isStrongPassword } from "@/lib/authValidation";
+
+export function AddUserDialog() {
+  const { addUser } = useAdminStore();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const reset = () => {
+    setName("");
+    setEmail("");
+    setPassword("");
+    setIsAdmin(false);
+    setError("");
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!isSubmitting) {
+      if (!next) reset();
+      setOpen(next);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return setError("Name is required");
+    if (!isValidEmail(email)) return setError("Enter a valid email address");
+    if (!isStrongPassword(password)) {
+      return setError(
+        "Password must be at least 8 characters and include uppercase, lowercase, number, and special character"
+      );
+    }
+    setError("");
+    setIsSubmitting(true);
+    const result = await addUser({ name, email, password, isAdmin });
+    setIsSubmitting(false);
+    if (!result.ok) {
+      setError(result.error ?? "Failed to add user");
+      return;
+    }
+    reset();
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm">
+          <UserPlus className="h-4 w-4" />
+          Add user
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add a new user</DialogTitle>
+          <DialogDescription>
+            Creates an account directly. The user can sign in immediately with
+            this password.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="p-3 text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="new-user-name">Name</Label>
+            <Input
+              id="new-user-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Jane Doe"
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="new-user-email">Email</Label>
+            <Input
+              id="new-user-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="jane@example.com"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="new-user-password">Temporary password</Label>
+            <Input
+              id="new-user-password"
+              type="text"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="At least 8 characters, mixed case, number, symbol"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="new-user-admin"
+              checked={isAdmin}
+              onCheckedChange={(checked) => setIsAdmin(checked === true)}
+            />
+            <Label htmlFor="new-user-admin" className="font-normal">
+              Grant admin access
+            </Label>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Adding…" : "Add user"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/componenets/Admin/AdminStatsGrid.tsx
+++ b/src/componenets/Admin/AdminStatsGrid.tsx
@@ -1,0 +1,69 @@
+import { Users, ShieldCheck, Ban, UserPlus2, CheckSquare, Bell, Target, Trophy } from "lucide-react";
+import { StatCard } from "@/componenets/Dashboard/StatCard";
+import type { AdminStats } from "@/zustand/adminStore";
+
+export function AdminStatsGrid({ stats }: { stats: AdminStats }) {
+  const todosDone = stats.todos.byStatus["Done"] ?? 0;
+  const goalsActive = stats.goals.byStatus["active"] ?? 0;
+
+  return (
+    <div className="grid grid-cols-2 gap-3 md:gap-4 lg:grid-cols-4">
+      <StatCard
+        icon={Users}
+        label="Total Users"
+        value={stats.users.total}
+        sub={`${stats.users.newLast7Days} new in last 7 days`}
+        accent="text-sky-400"
+      />
+      <StatCard
+        icon={ShieldCheck}
+        label="Admins"
+        value={stats.users.admins}
+        sub="with admin access"
+        accent="text-fuchsia-400"
+      />
+      <StatCard
+        icon={Ban}
+        label="Blocked Users"
+        value={stats.users.blocked}
+        sub="cannot sign in"
+        accent="text-red-400"
+      />
+      <StatCard
+        icon={UserPlus2}
+        label="New This Week"
+        value={stats.users.newLast7Days}
+        sub="signups in last 7 days"
+        accent="text-emerald-400"
+      />
+      <StatCard
+        icon={CheckSquare}
+        label="Todos"
+        value={stats.todos.total}
+        sub={`${todosDone} marked done`}
+        accent="text-amber-400"
+      />
+      <StatCard
+        icon={Bell}
+        label="Reminders"
+        value={stats.reminders.total}
+        sub={`${stats.reminders.completed} completed`}
+        accent="text-cyan-400"
+      />
+      <StatCard
+        icon={Target}
+        label="Habits"
+        value={stats.habits.total}
+        sub="tracked across all users"
+        accent="text-violet-400"
+      />
+      <StatCard
+        icon={Trophy}
+        label="Goals"
+        value={stats.goals.total}
+        sub={`${goalsActive} active`}
+        accent="text-rose-400"
+      />
+    </div>
+  );
+}

--- a/src/componenets/Admin/ResetPasswordResultDialog.tsx
+++ b/src/componenets/Admin/ResetPasswordResultDialog.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { Check, Copy, KeyRound } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+export type ResetPasswordResult = { email: string; code: string } | null;
+
+export function ResetPasswordResultDialog({
+  result,
+  onOpenChange,
+}: {
+  result: ResetPasswordResult;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!result) return;
+    await navigator.clipboard.writeText(result.code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <Dialog
+      open={!!result}
+      onOpenChange={(next) => {
+        if (!next) setCopied(false);
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <KeyRound className="h-4 w-4 text-sky-400" />
+            Password reset code generated
+          </DialogTitle>
+          <DialogDescription>
+            {result &&
+              `A reset code was generated for ${result.email}. In production this is emailed to the user — this test environment has no email transport, so it's shown here instead.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {result && (
+          <div className="flex items-center justify-between gap-3 rounded-md border border-white/10 bg-white/5 p-4">
+            <span className="text-2xl font-semibold tracking-[0.4em] text-white">
+              {result.code}
+            </span>
+            <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
+              {copied ? (
+                <>
+                  <Check className="h-4 w-4" /> Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="h-4 w-4" /> Copy
+                </>
+              )}
+            </Button>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/componenets/Admin/UsersTable.tsx
+++ b/src/componenets/Admin/UsersTable.tsx
@@ -1,0 +1,237 @@
+import { useState } from "react";
+import { format } from "date-fns";
+import { Ban, KeyRound, ShieldCheck, Trash2, UserCheck } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useAdminStore, type AdminUser } from "@/zustand/adminStore";
+import {
+  ResetPasswordResultDialog,
+  type ResetPasswordResult,
+} from "@/componenets/Admin/ResetPasswordResultDialog";
+
+type PendingAction = { type: "block" | "unblock" | "delete"; user: AdminUser };
+
+export function UsersTable({
+  users,
+  currentUserId,
+}: {
+  users: AdminUser[];
+  currentUserId: number | null;
+}) {
+  const { setUserBlocked, deleteUser, sendPasswordReset } = useAdminStore();
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [isActing, setIsActing] = useState(false);
+  const [actionError, setActionError] = useState("");
+  const [resetResult, setResetResult] = useState<ResetPasswordResult>(null);
+  const [resettingId, setResettingId] = useState<number | null>(null);
+
+  const handleConfirm = async () => {
+    if (!pendingAction) return;
+    setIsActing(true);
+    setActionError("");
+    const result =
+      pendingAction.type === "delete"
+        ? await deleteUser(pendingAction.user.id)
+        : await setUserBlocked(
+            pendingAction.user.id,
+            pendingAction.type === "block"
+          );
+    setIsActing(false);
+    if (!result.ok) {
+      setActionError(result.error ?? "Something went wrong");
+      return;
+    }
+    setPendingAction(null);
+  };
+
+  const handleResetPassword = async (user: AdminUser) => {
+    setResettingId(user.id);
+    const result = await sendPasswordReset(user.id);
+    setResettingId(null);
+    if (result.ok && result.email && result.code) {
+      setResetResult({ email: result.email, code: result.code });
+    }
+  };
+
+  if (users.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-white/50">No users yet.</p>
+    );
+  }
+
+  return (
+    <>
+      <div className="rounded-lg border border-white/10">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-white/10 hover:bg-transparent">
+              <TableHead className="text-white/60">User</TableHead>
+              <TableHead className="text-white/60">Joined</TableHead>
+              <TableHead className="text-white/60">Role</TableHead>
+              <TableHead className="text-white/60">Status</TableHead>
+              <TableHead className="text-white/60">Todos</TableHead>
+              <TableHead className="text-right text-white/60">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((user) => {
+              const isSelf = user.id === currentUserId;
+              return (
+                <TableRow key={user.id} className="border-white/10">
+                  <TableCell>
+                    <div className="font-medium text-white">{user.name}</div>
+                    <div className="text-xs text-white/50">{user.email}</div>
+                  </TableCell>
+                  <TableCell className="text-white/70">
+                    {format(new Date(user.createdAt), "MMM d, yyyy")}
+                  </TableCell>
+                  <TableCell>
+                    {user.isAdmin ? (
+                      <Badge className="gap-1 bg-sky-500/20 text-sky-300 border-sky-500/30">
+                        <ShieldCheck className="h-3 w-3" /> Admin
+                      </Badge>
+                    ) : (
+                      <Badge variant="outline" className="text-white/70">
+                        Member
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {user.isBlocked ? (
+                      <Badge variant="destructive">Blocked</Badge>
+                    ) : (
+                      <Badge className="bg-emerald-500/20 text-emerald-300 border-emerald-500/30">
+                        Active
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-white/70">{user.todoCount}</TableCell>
+                  <TableCell>
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        title="Send password reset code"
+                        disabled={resettingId === user.id}
+                        onClick={() => handleResetPassword(user)}
+                      >
+                        <KeyRound className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        title={user.isBlocked ? "Unblock user" : "Block user"}
+                        disabled={isSelf}
+                        onClick={() =>
+                          setPendingAction({
+                            type: user.isBlocked ? "unblock" : "block",
+                            user,
+                          })
+                        }
+                      >
+                        {user.isBlocked ? (
+                          <UserCheck className="h-4 w-4" />
+                        ) : (
+                          <Ban className="h-4 w-4" />
+                        )}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        title="Delete user"
+                        disabled={isSelf}
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => setPendingAction({ type: "delete", user })}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      <AlertDialog
+        open={!!pendingAction}
+        onOpenChange={(open) => {
+          if (!open && !isActing) {
+            setPendingAction(null);
+            setActionError("");
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingAction?.type === "delete"
+                ? "Delete this user?"
+                : pendingAction?.type === "block"
+                  ? "Block this user?"
+                  : "Unblock this user?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingAction?.type === "delete" &&
+                `This permanently deletes ${pendingAction.user.name}'s account and all of their data — todos, habits, reminders, and goals. This can't be undone.`}
+              {pendingAction?.type === "block" &&
+                `${pendingAction.user.name} will be signed out and won't be able to log back in until unblocked.`}
+              {pendingAction?.type === "unblock" &&
+                `${pendingAction.user.name} will be able to log in again.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {actionError && (
+            <div className="p-3 text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md">
+              {actionError}
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isActing}>Cancel</AlertDialogCancel>
+            <Button
+              type="button"
+              variant={pendingAction?.type === "delete" ? "destructive" : "default"}
+              disabled={isActing}
+              onClick={handleConfirm}
+            >
+              {isActing
+                ? "Working…"
+                : pendingAction?.type === "delete"
+                  ? "Delete user"
+                  : pendingAction?.type === "block"
+                    ? "Block user"
+                    : "Unblock user"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <ResetPasswordResultDialog
+        result={resetResult}
+        onOpenChange={(open) => !open && setResetResult(null)}
+      />
+    </>
+  );
+}

--- a/src/componenets/Sidebar.tsx
+++ b/src/componenets/Sidebar.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Link } from "@tanstack/react-router";
 import { useSidebarStore } from "@/zustand/sidebarStore";
-import { isAuthenticated } from "@/lib/authVerification";
+import { isAuthenticated, isAdminUser } from "@/lib/authVerification";
 import { logout } from "@/lib/authHelpers";
 import {
   LayoutDashboard,
@@ -13,6 +13,7 @@ import {
   Trophy,
   Bot,
   UserCircle,
+  ShieldCheck,
   ChevronLeft,
   ChevronRight,
   LogIn,
@@ -22,10 +23,12 @@ import {
 export function Sidebar() {
   const { isCollapsed, toggleSidebar } = useSidebarStore();
   const [isLoggedIn, setIsLoggedIn] = useState(isAuthenticated());
+  const [isAdmin, setIsAdmin] = useState(isAdminUser());
 
   useEffect(() => {
     const handleAuthChange = () => {
       setIsLoggedIn(isAuthenticated());
+      setIsAdmin(isAdminUser());
     };
     window.addEventListener("auth-change", handleAuthChange);
     return () => {
@@ -173,6 +176,20 @@ export function Sidebar() {
                   </Link>
                 </Button>
               )}
+
+              {isLoggedIn && isAdmin && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-10 w-10"
+                  title="Admin"
+                  asChild
+                >
+                  <Link to="/admin">
+                    <ShieldCheck className="h-5 w-5" />
+                  </Link>
+                </Button>
+              )}
             </div>
           ) : (
             // Expanded view - full content
@@ -271,6 +288,20 @@ export function Sidebar() {
                   <Link to="/profile">
                     <UserCircle className="h-4 w-4 mr-2" />
                     Profile
+                  </Link>
+                </Button>
+              )}
+
+              {isLoggedIn && isAdmin && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start px-0"
+                  asChild
+                >
+                  <Link to="/admin">
+                    <ShieldCheck className="h-4 w-4 mr-2" />
+                    Admin
                   </Link>
                 </Button>
               )}

--- a/src/lib/authVerification.ts
+++ b/src/lib/authVerification.ts
@@ -8,3 +8,14 @@ export function isAuthenticated() {
     : true;
   return !!token && !isExpired;
 }
+
+export function isAdminUser() {
+  const token = getAuthToken();
+  const payload = token?.split(".")[1];
+  if (!payload) return false;
+  try {
+    return !!JSON.parse(atob(payload)).isAdmin;
+  } catch {
+    return false;
+  }
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as GoalsRouteImport } from './routes/goals'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as FocusRouteImport } from './routes/focus'
 import { Route as AgentRouteImport } from './routes/agent'
+import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
 
 const VerifyEmailRoute = VerifyEmailRouteImport.update({
@@ -83,6 +84,11 @@ const AgentRoute = AgentRouteImport.update({
   path: '/agent',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminRoute = AdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -91,6 +97,7 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/agent': typeof AgentRoute
   '/focus': typeof FocusRoute
   '/forgot-password': typeof ForgotPasswordRoute
@@ -106,6 +113,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/agent': typeof AgentRoute
   '/focus': typeof FocusRoute
   '/forgot-password': typeof ForgotPasswordRoute
@@ -122,6 +130,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/agent': typeof AgentRoute
   '/focus': typeof FocusRoute
   '/forgot-password': typeof ForgotPasswordRoute
@@ -139,6 +148,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/admin'
     | '/agent'
     | '/focus'
     | '/forgot-password'
@@ -154,6 +164,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/admin'
     | '/agent'
     | '/focus'
     | '/forgot-password'
@@ -169,6 +180,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/admin'
     | '/agent'
     | '/focus'
     | '/forgot-password'
@@ -185,6 +197,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AdminRoute: typeof AdminRoute
   AgentRoute: typeof AgentRoute
   FocusRoute: typeof FocusRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
@@ -285,6 +298,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin': {
+      id: '/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AdminRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -297,6 +317,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AdminRoute: AdminRoute,
   AgentRoute: AgentRoute,
   FocusRoute: FocusRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -1,0 +1,101 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { ShieldAlert } from "lucide-react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { isAuthenticated, isAdminUser } from "@/lib/authVerification";
+import { getAuthToken } from "@/lib/authHelpers";
+import { useAdminStore } from "@/zustand/adminStore";
+import { AdminStatsGrid } from "@/componenets/Admin/AdminStatsGrid";
+import { UsersTable } from "@/componenets/Admin/UsersTable";
+import { AddUserDialog } from "@/componenets/Admin/AddUserDialog";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const Route = createFileRoute("/admin")({
+  component: RouteComponent,
+  beforeLoad: async () => {
+    if (!isAuthenticated()) {
+      throw redirect({ to: "/login" });
+    }
+    if (!isAdminUser()) {
+      throw redirect({ to: "/" });
+    }
+  },
+});
+
+function getCurrentUserId(): number | null {
+  const token = getAuthToken();
+  const payload = token?.split(".")[1];
+  if (!payload) return null;
+  try {
+    return JSON.parse(atob(payload)).userId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function AdminSkeleton() {
+  return (
+    <div className="max-w-7xl mx-auto p-2 md:p-4 space-y-6">
+      <Skeleton className="h-10 w-56" />
+      <div className="grid grid-cols-2 gap-3 md:gap-4 lg:grid-cols-4">
+        {[...Array(8)].map((_, i) => (
+          <Skeleton key={i} className="h-24 w-full rounded-xl" />
+        ))}
+      </div>
+      <Skeleton className="h-96 w-full rounded-xl" />
+    </div>
+  );
+}
+
+function RouteComponent() {
+  useDocumentTitle("Admin - Zendoro");
+
+  const { stats, users, fetchStats, fetchUsers, hasInitialized, error } =
+    useAdminStore();
+  const currentUserId = getCurrentUserId();
+
+  useEffect(() => {
+    fetchStats();
+    fetchUsers();
+  }, [fetchStats, fetchUsers]);
+
+  const isLoading = !hasInitialized;
+
+  if (isLoading) return <AdminSkeleton />;
+
+  return (
+    <div className="max-w-7xl mx-auto p-2 md:p-4 space-y-6 md:space-y-8">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="mb-1 text-2xl font-bold text-white md:text-4xl">
+            Admin
+          </h1>
+          <p className="text-sm text-white/70 md:text-base">
+            Platform-wide statistics and user management.
+          </p>
+        </div>
+        <AddUserDialog />
+      </header>
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md">
+          <ShieldAlert className="h-4 w-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {stats && (
+        <section>
+          <AdminStatsGrid stats={stats} />
+        </section>
+      )}
+
+      <section className="rounded-xl border border-white/10 bg-white/5 p-4 md:p-5">
+        <h2 className="mb-4 text-base font-semibold text-white md:text-lg">
+          Users
+        </h2>
+        <UsersTable users={users} currentUserId={currentUserId} />
+      </section>
+    </div>
+  );
+}

--- a/src/zustand/adminStore.ts
+++ b/src/zustand/adminStore.ts
@@ -1,0 +1,170 @@
+import { API_BASE_URL } from "@/constants/data";
+import { getAuthToken } from "@/lib/authHelpers";
+import { create } from "zustand";
+
+export type AdminStats = {
+  users: { total: number; admins: number; blocked: number; newLast7Days: number };
+  todos: { total: number; byStatus: Record<string, number> };
+  reminders: { total: number; completed: number };
+  habits: { total: number };
+  goals: { total: number; byStatus: Record<string, number> };
+};
+
+export type AdminUser = {
+  id: number;
+  name: string;
+  email: string;
+  isAdmin: boolean;
+  isBlocked: boolean;
+  createdAt: string;
+  todoCount: number;
+};
+
+const authHeaders = (): HeadersInit => ({
+  Authorization: `Bearer ${getAuthToken()}`,
+  "Content-Type": "application/json",
+});
+
+type AdminStore = {
+  stats: AdminStats | null;
+  users: AdminUser[];
+  isLoading: boolean;
+  hasInitialized: boolean;
+  error: string | null;
+  fetchStats: () => Promise<void>;
+  fetchUsers: () => Promise<void>;
+  addUser: (input: {
+    name: string;
+    email: string;
+    password: string;
+    isAdmin: boolean;
+  }) => Promise<{ ok: boolean; error?: string }>;
+  deleteUser: (id: number) => Promise<{ ok: boolean; error?: string }>;
+  setUserBlocked: (
+    id: number,
+    blocked: boolean
+  ) => Promise<{ ok: boolean; error?: string }>;
+  sendPasswordReset: (
+    id: number
+  ) => Promise<{ ok: boolean; email?: string; code?: string; error?: string }>;
+};
+
+export const useAdminStore = create<AdminStore>()((set, get) => ({
+  stats: null,
+  users: [],
+  isLoading: false,
+  hasInitialized: false,
+  error: null,
+
+  fetchStats: async () => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/admin/stats`, {
+        headers: authHeaders(),
+      });
+      if (!res.ok) throw new Error("Failed to load stats");
+      const stats: AdminStats = await res.json();
+      set({ stats });
+    } catch (e) {
+      console.error("Error fetching admin stats:", e);
+      set({ error: "Failed to load platform statistics." });
+    }
+  },
+
+  fetchUsers: async () => {
+    set({ isLoading: true });
+    try {
+      const res = await fetch(`${API_BASE_URL}/admin/users`, {
+        headers: authHeaders(),
+      });
+      if (!res.ok) throw new Error("Failed to load users");
+      const users: AdminUser[] = await res.json();
+      set({ users, isLoading: false, hasInitialized: true });
+    } catch (e) {
+      console.error("Error fetching users:", e);
+      set({
+        isLoading: false,
+        hasInitialized: true,
+        error: "Failed to load users.",
+      });
+    }
+  },
+
+  addUser: async (input) => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/admin/users`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        return { ok: false, error: err.message ?? "Failed to add user" };
+      }
+      const user: AdminUser = await res.json();
+      set({ users: [{ ...user, todoCount: 0 }, ...get().users] });
+      get().fetchStats();
+      return { ok: true };
+    } catch {
+      return { ok: false, error: "Failed to add user" };
+    }
+  },
+
+  deleteUser: async (id) => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/admin/users/${id}`, {
+        method: "DELETE",
+        headers: authHeaders(),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        return { ok: false, error: err.message ?? "Failed to delete user" };
+      }
+      set({ users: get().users.filter((u) => u.id !== id) });
+      get().fetchStats();
+      return { ok: true };
+    } catch {
+      return { ok: false, error: "Failed to delete user" };
+    }
+  },
+
+  setUserBlocked: async (id, blocked) => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/admin/users/${id}/block`, {
+        method: "PATCH",
+        headers: authHeaders(),
+        body: JSON.stringify({ blocked }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        return { ok: false, error: err.message ?? "Failed to update user" };
+      }
+      const updated: AdminUser = await res.json();
+      set({
+        users: get().users.map((u) =>
+          u.id === id ? { ...u, isBlocked: updated.isBlocked } : u
+        ),
+      });
+      get().fetchStats();
+      return { ok: true };
+    } catch {
+      return { ok: false, error: "Failed to update user" };
+    }
+  },
+
+  sendPasswordReset: async (id) => {
+    try {
+      const res = await fetch(
+        `${API_BASE_URL}/admin/users/${id}/reset-password`,
+        { method: "POST", headers: authHeaders() }
+      );
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        return { ok: false, error: err.message ?? "Failed to send reset code" };
+      }
+      const data = await res.json();
+      return { ok: true, email: data.email, code: data.code };
+    } catch {
+      return { ok: false, error: "Failed to send reset code" };
+    }
+  },
+}));

--- a/test-backend/index.js
+++ b/test-backend/index.js
@@ -16,16 +16,71 @@ const pool = new Pool({
 
 const JWT_SECRET = process.env.JWT_SECRET || "zendoro-test-secret";
 
-function auth(req, res, next) {
+// Verifies the JWT and also rejects blocked users on every request (not just
+// at login), so an admin blocking a user takes effect immediately even if
+// that user still holds a valid, unexpired token.
+async function auth(req, res, next) {
   const header = req.headers.authorization;
   if (!header) return res.status(401).json({ message: "No token" });
   try {
     const decoded = jwt.verify(header.split(" ")[1], JWT_SECRET);
+    const { rows } = await pool.query(
+      "SELECT is_blocked FROM users WHERE id = $1",
+      [decoded.userId]
+    );
+    if (!rows[0]) return res.status(401).json({ message: "User not found" });
+    if (rows[0].is_blocked) {
+      return res.status(403).json({ message: "Your account has been blocked." });
+    }
     req.userId = decoded.userId;
     next();
   } catch {
     res.status(401).json({ message: "Invalid token" });
   }
+}
+
+async function requireAdmin(req, res, next) {
+  try {
+    const { rows } = await pool.query(
+      "SELECT is_admin FROM users WHERE id = $1",
+      [req.userId]
+    );
+    if (!rows[0]?.is_admin) {
+      return res.status(403).json({ message: "Admin access required" });
+    }
+    next();
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+}
+
+function userRow(r) {
+  return {
+    id: r.id,
+    name: r.name,
+    email: r.email,
+    isAdmin: r.is_admin,
+    isBlocked: r.is_blocked,
+    createdAt: r.created_at,
+  };
+}
+
+function generateResetCode() {
+  return String(Math.floor(100000 + Math.random() * 900000));
+}
+
+// Creates a fresh 6-digit reset code for a user, replacing any prior codes.
+async function issuePasswordResetCode(userId) {
+  const code = generateResetCode();
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+  await pool.query("DELETE FROM password_reset_codes WHERE user_id = $1", [
+    userId,
+  ]);
+  await pool.query(
+    "INSERT INTO password_reset_codes (user_id, code, expires_at) VALUES ($1, $2, $3)",
+    [userId, code, expiresAt]
+  );
+  return code;
 }
 
 function todoRow(r) {
@@ -111,11 +166,78 @@ app.post("/auth/login", async (req, res) => {
     if (!user || !bcrypt.compareSync(password, user.password)) {
       return res.status(401).json({ message: "Invalid credentials" });
     }
-    const token = jwt.sign({ userId: user.id }, JWT_SECRET, {
-      expiresIn: "7d",
-    });
+    if (user.is_blocked) {
+      return res
+        .status(403)
+        .json({ message: "Your account has been blocked. Contact support." });
+    }
+    const token = jwt.sign(
+      { userId: user.id, isAdmin: user.is_admin },
+      JWT_SECRET,
+      { expiresIn: "7d" }
+    );
     res.json({
       message: "Login successful",
+      user: { id: user.id, name: user.name, email: user.email },
+      token,
+    });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// Always responds 200 regardless of whether the email exists, to avoid
+// leaking which addresses are registered.
+app.post("/auth/forgot-password", async (req, res) => {
+  try {
+    const { email } = req.body;
+    const { rows } = await pool.query("SELECT id, is_blocked FROM users WHERE email = $1", [
+      email,
+    ]);
+    const user = rows[0];
+    if (user && !user.is_blocked) {
+      const code = await issuePasswordResetCode(user.id);
+      console.log(`[test-backend] Password reset code for ${email}: ${code}`);
+    }
+    res.json({ message: "If that email exists, a reset code has been sent." });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post("/auth/reset-password", async (req, res) => {
+  try {
+    const { email, code, newPassword } = req.body;
+    const { rows: userRows } = await pool.query(
+      "SELECT * FROM users WHERE email = $1",
+      [email]
+    );
+    const user = userRows[0];
+    if (!user) {
+      return res.status(400).json({ error: "Invalid or expired code" });
+    }
+    const { rows: codeRows } = await pool.query(
+      "SELECT * FROM password_reset_codes WHERE user_id = $1 AND code = $2 AND expires_at > NOW()",
+      [user.id, code]
+    );
+    if (codeRows.length === 0) {
+      return res.status(400).json({ error: "Invalid or expired code" });
+    }
+    const hashed = bcrypt.hashSync(newPassword, 10);
+    await pool.query("UPDATE users SET password = $1 WHERE id = $2", [
+      hashed,
+      user.id,
+    ]);
+    await pool.query("DELETE FROM password_reset_codes WHERE user_id = $1", [
+      user.id,
+    ]);
+    const token = jwt.sign(
+      { userId: user.id, isAdmin: user.is_admin },
+      JWT_SECRET,
+      { expiresIn: "7d" }
+    );
+    res.json({
+      message: "Password reset successful",
       user: { id: user.id, name: user.name, email: user.email },
       token,
     });
@@ -133,7 +255,7 @@ app.post("/auth/signup", async (req, res) => {
       [name, email, hashed]
     );
     const user = rows[0];
-    const token = jwt.sign({ userId: user.id }, JWT_SECRET, {
+    const token = jwt.sign({ userId: user.id, isAdmin: false }, JWT_SECRET, {
       expiresIn: "7d",
     });
     res.json({ message: "User created", user, token });
@@ -573,6 +695,156 @@ app.post("/timer/session-count", auth, async (req, res) => {
       );
     }
     res.json({ message: "Session count updated" });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// ── Admin ─────────────────────────────────────────────────────────────────────
+
+app.get("/admin/stats", auth, requireAdmin, async (req, res) => {
+  try {
+    const [
+      users,
+      todosByStatus,
+      reminders,
+      habits,
+      goalsByStatus,
+    ] = await Promise.all([
+      pool.query(
+        `SELECT
+          COUNT(*)::int AS total,
+          COUNT(*) FILTER (WHERE is_admin)::int AS admins,
+          COUNT(*) FILTER (WHERE is_blocked)::int AS blocked,
+          COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '7 days')::int AS new_last_7_days
+        FROM users`
+      ),
+      pool.query(`SELECT status, COUNT(*)::int AS count FROM todos GROUP BY status`),
+      pool.query(
+        `SELECT COUNT(*)::int AS total, COUNT(*) FILTER (WHERE completed)::int AS completed
+         FROM reminders`
+      ),
+      pool.query(`SELECT COUNT(*)::int AS total FROM hobbies`),
+      pool.query(`SELECT status, COUNT(*)::int AS count FROM goals GROUP BY status`),
+    ]);
+
+    res.json({
+      users: {
+        total: users.rows[0].total,
+        admins: users.rows[0].admins,
+        blocked: users.rows[0].blocked,
+        newLast7Days: users.rows[0].new_last_7_days,
+      },
+      todos: {
+        total: todosByStatus.rows.reduce((sum, r) => sum + r.count, 0),
+        byStatus: Object.fromEntries(
+          todosByStatus.rows.map((r) => [r.status, r.count])
+        ),
+      },
+      reminders: {
+        total: reminders.rows[0].total,
+        completed: reminders.rows[0].completed,
+      },
+      habits: { total: habits.rows[0].total },
+      goals: {
+        total: goalsByStatus.rows.reduce((sum, r) => sum + r.count, 0),
+        byStatus: Object.fromEntries(
+          goalsByStatus.rows.map((r) => [r.status, r.count])
+        ),
+      },
+    });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.get("/admin/users", auth, requireAdmin, async (req, res) => {
+  try {
+    const { rows } = await pool.query(`
+      SELECT u.*, COALESCE(t.todo_count, 0)::int AS todo_count
+      FROM users u
+      LEFT JOIN (
+        SELECT user_id, COUNT(*) AS todo_count FROM todos GROUP BY user_id
+      ) t ON t.user_id = u.id
+      ORDER BY u.created_at DESC
+    `);
+    res.json(rows.map((r) => ({ ...userRow(r), todoCount: r.todo_count })));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post("/admin/users", auth, requireAdmin, async (req, res) => {
+  try {
+    const { name, email, password, isAdmin } = req.body;
+    if (!name || !email || !password) {
+      return res.status(400).json({ message: "name, email, and password are required" });
+    }
+    const hashed = bcrypt.hashSync(password, 10);
+    const { rows } = await pool.query(
+      "INSERT INTO users (name, email, password, is_admin) VALUES ($1, $2, $3, $4) RETURNING *",
+      [name, email, hashed, !!isAdmin]
+    );
+    res.json(userRow(rows[0]));
+  } catch (err) {
+    if (err.code === "23505") {
+      return res.status(409).json({ message: "A user with that email already exists" });
+    }
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.delete("/admin/users/:id", auth, requireAdmin, async (req, res) => {
+  try {
+    const targetId = Number(req.params.id);
+    if (targetId === req.userId) {
+      return res.status(400).json({ message: "You cannot delete your own account" });
+    }
+    await pool.query("DELETE FROM users WHERE id = $1", [targetId]);
+    res.json({ message: "Deleted" });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.patch("/admin/users/:id/block", auth, requireAdmin, async (req, res) => {
+  try {
+    const targetId = Number(req.params.id);
+    const { blocked } = req.body;
+    if (targetId === req.userId) {
+      return res.status(400).json({ message: "You cannot block your own account" });
+    }
+    const { rows } = await pool.query(
+      "UPDATE users SET is_blocked = $1 WHERE id = $2 RETURNING *",
+      [!!blocked, targetId]
+    );
+    if (!rows[0]) return res.status(404).json({ message: "Not found" });
+    res.json(userRow(rows[0]));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// Generates a password reset code for the target user. This test backend has
+// no email transport, so the code is logged to the console (simulating the
+// email) and also returned in the response for local development purposes.
+app.post("/admin/users/:id/reset-password", auth, requireAdmin, async (req, res) => {
+  try {
+    const targetId = Number(req.params.id);
+    const { rows } = await pool.query("SELECT * FROM users WHERE id = $1", [
+      targetId,
+    ]);
+    const user = rows[0];
+    if (!user) return res.status(404).json({ message: "Not found" });
+    const code = await issuePasswordResetCode(user.id);
+    console.log(
+      `[test-backend] Admin-triggered password reset for ${user.email}: ${code}`
+    );
+    res.json({
+      message: `Reset code generated for ${user.email}`,
+      email: user.email,
+      code,
+    });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/test-backend/seed.js
+++ b/test-backend/seed.js
@@ -31,6 +31,16 @@ async function seed() {
       name VARCHAR(255) NOT NULL,
       email VARCHAR(255) UNIQUE NOT NULL,
       password VARCHAR(255) NOT NULL,
+      is_admin BOOLEAN DEFAULT false,
+      is_blocked BOOLEAN DEFAULT false,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS password_reset_codes (
+      id SERIAL PRIMARY KEY,
+      user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+      code VARCHAR(6) NOT NULL,
+      expires_at TIMESTAMP NOT NULL,
       created_at TIMESTAMP DEFAULT NOW()
     );
 
@@ -115,7 +125,39 @@ async function seed() {
     );
   `);
 
-  // Skip seeding if user already exists
+  // Migrate existing databases (persisted volumes) that predate the admin columns.
+  await pool.query(`
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT false;
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS is_blocked BOOLEAN DEFAULT false;
+  `);
+
+  // Ensure the admin and secondary demo users exist even on a database that
+  // was already seeded before these accounts were introduced.
+  const { rows: existingAdmin } = await pool.query(
+    "SELECT id FROM users WHERE email = $1",
+    ["admin@zendoro.dev"]
+  );
+  if (existingAdmin.length === 0) {
+    const adminPasswordHash = bcrypt.hashSync("admin123", 10);
+    await pool.query(
+      "INSERT INTO users (name, email, password, is_admin) VALUES ($1, $2, $3, true)",
+      ["Zendoro Admin", "admin@zendoro.dev", adminPasswordHash]
+    );
+    console.log(`Seeded admin user: admin@zendoro.dev / admin123`);
+  }
+  const { rows: existingBob } = await pool.query(
+    "SELECT id FROM users WHERE email = $1",
+    ["bob@zendoro.dev"]
+  );
+  if (existingBob.length === 0) {
+    const bobPasswordHash = bcrypt.hashSync("password123", 10);
+    await pool.query(
+      "INSERT INTO users (name, email, password) VALUES ($1, $2, $3)",
+      ["Bob Demo", "bob@zendoro.dev", bobPasswordHash]
+    );
+  }
+
+  // Skip the larger demo-data seed if the primary test user already exists
   const { rows: existing } = await pool.query(
     "SELECT id FROM users WHERE email = $1",
     ["test@zendoro.dev"]


### PR DESCRIPTION
## Summary
- New `/admin` route (admin-only, gated by an `isAdmin` JWT claim + route guard) with:
  - Platform-wide stats: users (total/admins/blocked/new this week), todos by status, reminders, habits, goals
  - Users table: add, delete, block/unblock, send password reset — with confirmation dialogs and self-action guards (can't block/delete yourself)
- Sidebar shows an "Admin" link only for admins
- `src/lib/authVerification.ts`: new `isAdminUser()` helper decoding the JWT claim
- `src/zustand/adminStore.ts`: new store wired to `/admin/*` endpoints, matching **[zendoro-backend#14](https://github.com/Amirali-Khamseh/zendoro-backend/pull/14)** exactly — no changes needed on either side once both merge
- `test-backend/` (local docker-compose dev mock): added the same admin endpoints, plus previously missing `/auth/forgot-password` and `/auth/reset-password` (needed to test the reset-password-email flow locally, since the mock backend didn't implement them at all)

